### PR TITLE
variants/{novacustom_ns5x,tuxedo_ibs15}: flash the COREBOOT region

### DIFF
--- a/docs/variants/novacustom_ns5x/installation.md
+++ b/docs/variants/novacustom_ns5x/installation.md
@@ -77,11 +77,17 @@ Steps for initial Dasharo installation:
 
 ### Updating Dasharo
 
-If Dasharo is currently installed, only the RW_SECTION_A partition of the flash
-needs to be updated. Flash it using the following command:
+If Dasharo v1.1.0 or newer is currently installed, only the COREBOOT partition
+of the flash needs to be updated. Flash it using the following command:
 
 ```bash
-# flashrom -p internal -w [path] --fmap -i RW_SECTION_A
+# flashrom -p internal -w [path] --fmap -i COREBOOT
 ```
 
 This command also preserves UEFI settings and the boot order.
+
+Otherwise, use the following command:
+
+```bash
+# flashrom -p internal -w [path] --ifd -i bios
+```

--- a/docs/variants/tuxedo_ibs15/installation.md
+++ b/docs/variants/tuxedo_ibs15/installation.md
@@ -74,11 +74,9 @@ required. Follow the steps below:
 
 ### Updating Dasharo
 
-If Dasharo is currently installed, only the RW_SECTION_A partition of the flash
-needs to be updated. Flash it using the following command:
+If Dasharo is currently installed, only the BIOS region of the flash needs to be
+updated. Flash it using the following command:
 
 ```bash
-# flashrom -p internal -w [path] --fmap -i RW_SECTION_A
+# flashrom -p internal -w [path] --ifd -i bios
 ```
-
-This command also preserves UEFI settings and the boot order.


### PR DESCRIPTION
Vboot was disabled on these laptops, so the flashing instructions need to be updated.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>