### PR TITLE
variants/dell_optiplex: minor corrections of update and recovery proc…

### DIFF
--- a/docs/variants/dell_optiplex/firmware-update.md
+++ b/docs/variants/dell_optiplex/firmware-update.md
@@ -14,10 +14,11 @@ For simplicity we recommend using network booted
 
 * Make sure a wired network cable to the device's Ethernet port
 * Perform DTS network boot
-  * Dasharo (coreboot+SeaBIOS)
-    * SeaBIOS menu choose Dasharo Network Boot Menu
-  * Dasharo (coreboot+UEFI)
-    * Press F7 and choose iPXE Network boot
+    - Dasharo (coreboot+SeaBIOS)
+        * While booting enter SeaBIOS menu using ++esc++
+        * Choose option `iPXE (PCI 00:19.0)`
+    - Dasharo (coreboot+UEFI)
+        * Press F7 and choose iPXE Network boot
 * In the Dasharo Network Boot Menu, select the `Dasharo Tools Suite` option
 * Enter shell using option `9)`
 * Download the Dell OptiPlex 7010/9010 Dasharo from

--- a/docs/variants/dell_optiplex/firmware-update.md
+++ b/docs/variants/dell_optiplex/firmware-update.md
@@ -10,10 +10,14 @@ distribution update.
 For simplicity we recommend using network booted
 [Dasharo Tools Suite](../../../common-coreboot-docs/dasharo_tools_suite).
 
-### Dasharo (coreboot+SeaBIOS) update
+### Dasharo (coreboot+SeaBIOS) and Dasharo (coreboot+UEFI) update
 
 * Make sure a wired network cable to the device's Ethernet port
-* Boot platform and from SeaBIOS menu choose Dasharo Network Boot Menu
+* Perform DTS network boot
+  * Dasharo (coreboot+SeaBIOS)
+    * SeaBIOS menu choose Dasharo Network Boot Menu
+  * Dasharo (coreboot+UEFI)
+    * Press F7 and choose iPXE Network boot
 * In the Dasharo Network Boot Menu, select the `Dasharo Tools Suite` option
 * Enter shell using option `9)`
 * Download the Dell OptiPlex 7010/9010 Dasharo from

--- a/docs/variants/dell_optiplex/recovery.md
+++ b/docs/variants/dell_optiplex/recovery.md
@@ -111,16 +111,12 @@ pin of `SPI_1` chip, marked with a small dot engraved on the chip.
 
 ## Step 5: Prepare recovery binary
 
-1. Get v0.2-rc3 binary
+Following procedure assume that you use recovery binary created during [backup
+process](../../..//osf-trivia-list/deployment/#how-to-use-flashrom-to-backup-vendor-bios).
+Backup has 12MB, so it have to be split
 
 ```bash
-wget https://cloud.3mdeb.com/index.php/s/8WNEHEFcBGFRK23/download -O dasharo_dell_optiplex_9010_v0.2-rc3.rom
-```
-
-1. It has 12MB, so it have to be split
-
-```bash
-split -b4M dasharo_dell_optiplex_9010_v0.2-rc3.rom
+split -b4M bios_backup_YYYYMMDD.bin
 ```
 
 ## Step 6: Flash 4MB (BIOS) part


### PR DESCRIPTION
…edures

Firmware update have to be distinguished between coreboot+SeaBIOS and coreboot+UEFI.

Recovery procedure should not contain links to deprecated binaries.

Signed-off-by: Piotr Król <piotr.krol@3mdeb.com>