### PR TITLE
dasharo-tools-suite: documentation formatting and v1.1.1 release

### DIFF
--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -532,7 +532,7 @@ executed automatically after startup.
 
 Here is simple instruction on how to use that feature:
 
-- Run the HTTP server in the directory which contains DTS base image. If you
+* Run the HTTP server in the directory which contains DTS base image. If you
 build it by yourself, then it should be `meta-dts` subdirectory:
 `build/tmp/deploy/images/genericx86-64`
 
@@ -542,7 +542,7 @@ The easiest way to start an HTTP server is using `http.server` python module:
 $ python3 -m http.server 9000
 ```
 
-- Create `dts.ipxe` bootchain file in directory where you have a running HTTP
+* Create `dts.ipxe` bootchain file in directory where you have a running HTTP
 server. That file should have similar content (you need to enter IP of your
 host machine in a local network):
 
@@ -555,9 +555,9 @@ module http://<YOUR_IP>:9000/ipxe-commands /sbin/ipxe-commands mode=755
 boot
 ```
 
-- Copy your `ipxe-commands` script in this same directory
+* Copy your `ipxe-commands` script in this same directory
 
-- Enter the iPXE shell on your device and load `dts.ipxe` chainboot file:
+* Enter the iPXE shell on your device and load `dts.ipxe` chainboot file:
 
 ```bash
 iPXE> dhcp

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -14,8 +14,7 @@ that it boots on the following platforms:
 * NovaCustom NV4x ([test
   report](https://docs.google.com/spreadsheets/d/1LOXY9HCu-fMitkYwX08iLsQdSNenzyU0LnMdVbZB5Do/edit#gid=536764189&range=A161)),
 * NovaCustom NS5x/7x ([test
-  report](https://docs.google.com/spreadsheets/d/1LOXY9HCu-fMitkYwX08iLsQdSNenzyU0LnMdVbZB5Do/edit#gid=38447675&range=A174)),
-* Protectli FW6/VP46xx.
+  report](https://docs.google.com/spreadsheets/d/1LOXY9HCu-fMitkYwX08iLsQdSNenzyU0LnMdVbZB5Do/edit#gid=38447675&range=A174)).
 
 <span style="color:red">
 Please do not use DTS v1.1.0 to deploy Dasharo on MSI PRO Z690-A (WIFI) DDR5;

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -5,15 +5,15 @@
 Dasharo Tools Suite was prepared to run on x86 platforms, but we can confirm
 that it boots on the following platforms:
 
-* ASUS KGPE-D16
-* Dell OptiPlex 7010/9010
+* ASUS KGPE-D16,
+* Dell OptiPlex 7010/9010,
 * MSI PRO Z690-A DDR4 ([test
-  report](https://docs.google.com/spreadsheets/d/16wokQYhtS7XA1DQC3Om7FY-IImG6SZisGK7NnzyRGVY/edit#gid=0&range=A75))
+  report](https://docs.google.com/spreadsheets/d/16wokQYhtS7XA1DQC3Om7FY-IImG6SZisGK7NnzyRGVY/edit#gid=0&range=A75)),
 * NovaCustom NV4x ([test
-  report](https://docs.google.com/spreadsheets/d/1LOXY9HCu-fMitkYwX08iLsQdSNenzyU0LnMdVbZB5Do/edit#gid=536764189&range=A161))
+  report](https://docs.google.com/spreadsheets/d/1LOXY9HCu-fMitkYwX08iLsQdSNenzyU0LnMdVbZB5Do/edit#gid=536764189&range=A161)),
 * NovaCustom NS5x/7x ([test
-  report](https://docs.google.com/spreadsheets/d/1LOXY9HCu-fMitkYwX08iLsQdSNenzyU0LnMdVbZB5Do/edit#gid=38447675&range=A174))
-* Protectli FW6/VP46xx
+  report](https://docs.google.com/spreadsheets/d/1LOXY9HCu-fMitkYwX08iLsQdSNenzyU0LnMdVbZB5Do/edit#gid=38447675&range=A174)),
+* Protectli FW6/VP46xx.
 
 <span style="color:red">
 Please do not use DTS to deploy Dasharo on MSI PRO Z690-A (WIFI) DDR5;
@@ -40,9 +40,12 @@ This section describes how to boot DTS using iPXE.
 
 #### Requirements
 
-* Dasharo device with DTS functionality integrated
-* Wired network connection
-* [Secure Boot disabled](#disabling-secure-boot)
+Below are the requirements that must be met to run DTS over network on the
+platform:
+
+* Dasharo device with DTS functionality integrated,
+* wired network connection,
+* [Secure Boot disabled](#disabling-secure-boot).
 
 #### Launching DTS
 
@@ -60,10 +63,13 @@ This section describes how to boot DTS using USB stick.
 
 #### Requirements
 
-* USB stick (at least 2GB)
-* Wired network connection
-* [Secure Boot disabled](#disabling-secure-boot)
-* Latest image from [releases](./releases.md) section
+Below are the requirements that must be met to run DTS from USB device on the
+platform:
+
+* USB stick (at least 2GB),
+* wired network connection,
+* [Secure Boot disabled](#disabling-secure-boot),
+* latest image from [releases](./releases.md) section.
 
 #### Launching DTS
 
@@ -94,10 +100,12 @@ the process should be significantly decreased.
 
 ### Prerequisites
 
-* Linux PC (tested on `Ubuntu 20.04 LTS`)
-* [docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/) installed
+The following must be met to build DTS:
+
+* Linux PC (tested on `Ubuntu 20.04 LTS`),
+* [docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/) installed,
 * [kas-container 3.0.2](https://raw.githubusercontent.com/siemens/kas/3.0.2/kas-container)
-  script downloaded and available in [PATH](https://en.wikipedia.org/wiki/PATH_(variable))
+  script downloaded and available in [PATH](https://en.wikipedia.org/wiki/PATH_(variable)),
 
 ```bash
 wget -O ~/bin/kas-container https://raw.githubusercontent.com/siemens/kas/3.0.2/kas-container
@@ -107,7 +115,7 @@ wget -O ~/bin/kas-container https://raw.githubusercontent.com/siemens/kas/3.0.2/
 chmod +x ~/bin/kas-container
 ```
 
-* `meta-dts` repository cloned
+* `meta-dts` repository cloned.
 
 ```bash
 mkdir yocto && cd yocto
@@ -125,7 +133,7 @@ From `yocto` directory run:
 SHELL=/bin/bash kas-container build meta-dts/kas.yml
 ```
 
-* Image build takes time, so be patient and after build's finish you should see
+Image build takes time, so be patient and after build's finish you should see
 something similar to (the exact tasks numbers may differ):
 
 ```shell
@@ -159,7 +167,7 @@ local_conf_header:
 
 ### Flash
 
-* Find out your device name:
+* Find out your device name.
 
 ```shell
 fdisk -l
@@ -178,7 +186,7 @@ in this case the device name is `/dev/sdx` **but be aware, in next steps
 replace `/dev/sdx` with right device name on your platform or else you can
 damage your system!.**
 
-* From where you ran image build type:
+* From where you ran image build type.
 
 ```shell
 sudo umount /dev/sdx*
@@ -192,7 +200,7 @@ Here the file `dts-base-image-genericx86-64.wic.gz` should be available which
 is the image of DTS. To flash image you can use the same command as showed in
 [running section](#launching-dts_1), just change the file name.
 
-* Boot the platform
+* Boot the platform.
 
 ## Disabling Secure Boot
 
@@ -220,12 +228,12 @@ You could confirm that by repeating steps 3 - 5.
 
 This section describes functionality of Dasharo Tools Suite. These are:
 
-* [Dasharo zero-touch initial deployment](#dasharo-zero-touch-initial-deployment)
-* [HCL Report](#hcl-report)
-* [Firmware update](#firmware-update)
-* [EC Transition](#ec-transition)
-* [EC update](#ec-update)
-* [Run commands from iPXE shell](#ipxe-commands)
+* [Dasharo zero-touch initial deployment](#dasharo-zero-touch-initial-deployment),
+* [HCL Report](#hcl-report),
+* [Firmware update](#firmware-update),
+* [EC Transition](#ec-transition),
+* [EC update](#ec-update),
+* [Run commands from iPXE shell](#ipxe-commands).
 
 ### Dasharo zero-touch initial deployment
 
@@ -347,10 +355,10 @@ Currently, this functionality is supported on the
 To perform EC transition, make sure you are
 [running DTS version v1.0.2 or higher](#running) and follow these steps:
 
-* After boot, choose option number 6 open custom vendor submenu
+* After boot, choose option number 6 open custom vendor submenu.
 * Plug in power supply (without it, flashing EC is not possible as losing power
-  may result in firmware corruption)
-* Choose option number 1 to perform full EC transition
+  may result in firmware corruption).
+* Choose option number 1 to perform full EC transition.
   > Note: below is an example output from Embedded Controller transition on
     NovaCustom NS50MU laptop.
 
@@ -434,7 +442,7 @@ To perform EC transition, make sure you are
 * Power on your computer. Booting process may take a while.
 * After boot, choose option number 9 to drop to Shell.
 * Your firmware is correctly installed. You can retrieve EC firmware information
-  using:
+  using `system76_ectool` utility.
 
   ```bash
   system76_ectool info
@@ -443,14 +451,14 @@ To perform EC transition, make sure you are
   The output of the above command should contain information about
   the version of flashed firmware:
 
-* on `NovaCustom NS5x/NS7x`
+* The following presents how it should look on `NovaCustom NS5x/NS7x`.
 
   ```bash
   board: clevo/ns50mu
   version: 2022-08-31_cbff21b
   ```
 
-* on `NovaCustom NV4x`
+* The following presents how it should look on  `NovaCustom NV4x`.
 
   ```bash
   board: clevo/nv40mz
@@ -460,9 +468,9 @@ To perform EC transition, make sure you are
 ### EC update
 
 DTS allows to update open-source Embedded Controller firmware to the newer
-version. To properly update it, follow these steps:
+version. This is how we can achieve that.
 
-* Retrieve information about your current EC
+* Retrieve information about your current EC.
 
   ```bash
   system76_ectool info
@@ -479,7 +487,7 @@ version. To properly update it, follow these steps:
 * Download the newest version of Embedded Controller firmware.
 * Plug in power supply, without it, flashing EC is not possible as losing power
   may cause in damaged firmware.
-* Flash Embedded Controller firmware internally:
+* Flash Embedded Controller firmware internally.
 
   ```bash
   system76_ectool flash ec_file.rom
@@ -510,7 +518,7 @@ version. To properly update it, follow these steps:
 * Computer will shut down automatically.
 * Power on your computer. Booting process may take a while.
 * After boot, choose option number 9 to drop to Shell.
-* Retrieve information about your updated EC
+* Retrieve information about your updated EC.
 
   ```bash
   system76_ectool info
@@ -530,13 +538,13 @@ There is a possibility to execute the bash script after Linux startup by passing
 it from the iPXE shell. Every script placed in `/sbin/ipxe-commands` will be
 executed automatically after startup.
 
-Here is simple instruction on how to use that feature:
+Here is simple instruction on how to use that feature.
 
 * Run the HTTP server in the directory which contains DTS base image. If you
 build it by yourself, then it should be `meta-dts` subdirectory:
-`build/tmp/deploy/images/genericx86-64`
+`build/tmp/deploy/images/genericx86-64`.
 
-The easiest way to start an HTTP server is using `http.server` python module:
+The easiest way to start an HTTP server is using `http.server` python module.
 
 ```bash
 $ python3 -m http.server 9000
@@ -544,7 +552,7 @@ $ python3 -m http.server 9000
 
 * Create `dts.ipxe` bootchain file in directory where you have a running HTTP
 server. That file should have similar content (you need to enter IP of your
-host machine in a local network):
+host machine in a local network).
 
 ```bash
 #!ipxe
@@ -555,9 +563,9 @@ module http://<YOUR_IP>:9000/custom-script /sbin/ipxe-commands mode=755
 boot
 ```
 
-* Copy your `custom-script` script in this same directory
+* Copy your `custom-script` script in this same directory.
 
-* Enter the iPXE shell on your device and load `dts.ipxe` chainboot file:
+* Enter the iPXE shell on your device and load `dts.ipxe` chainboot file.
 
 ```bash
 iPXE> dhcp

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -28,19 +28,19 @@ to be fixed before it is possible:
 The Dasharo Tools Suite can be started in various ways. Currently, there are
 two options:
 
-* bootable over network (iPXE),
+* bootable over a network (iPXE),
 * bootable USB stick image.
 
-The first one should be always preferred if possible, as it the easiest one to
-use.
+The first one should always be preferred if possible, as it is the easiest one
+to use.
 
-### Bootable over network
+### Bootable over a network
 
 This section describes how to boot DTS using iPXE.
 
 #### Requirements
 
-Below are the requirements that must be met to run DTS over network on the
+Below are the requirements that must be met to run DTS over a network on the
 platform:
 
 * Dasharo device with DTS functionality integrated,
@@ -59,11 +59,11 @@ To access Dasharo Tools Suite:
 
 ### Bootable USB stick
 
-This section describes how to boot DTS using USB stick.
+This section describes how to boot DTS using a USB stick.
 
 #### Requirements
 
-Below are the requirements that must be met to run DTS from USB device on the
+Below are the requirements that must be met to run DTS from a USB device on the
 platform:
 
 * USB stick (at least 2GB),
@@ -76,17 +76,17 @@ platform:
 To access Dasharo Tools Suite:
 
 * flash the downloaded image onto USB stick,
-    - you can use cross-platform GUI installer - [Etcher](https://www.balena.io/etcher/)
-    - you can also use `dd` to flash from command line
+    - you can use a cross-platform GUI installer - [Etcher](https://www.balena.io/etcher/)
+    - you can also use `dd` to flash from the command line
 
 ```bash
 gzip -cdk dts-base-image-v1.1.0.wic.gz | \
 sudo dd of=/dev/sdX bs=16M status=progress conv=fdatasync
 ```
 
-> Note: this is an example for v1.1.0 image.
+> Note: this is an example done on the v1.1.0 image.
 
-* insert the USB stick to a USB in your device,
+* insert the USB stick into a USB in your device,
 * boot from the USB stick,
 * the DTS menu will now appear.
 
@@ -94,9 +94,9 @@ sudo dd of=/dev/sdX bs=16M status=progress conv=fdatasync
 
 We choose [Yocto Project](https://www.yoctoproject.org/) to prepare Dasharo
 Tools Suite system. DTS image can be built using publicly available sources.
-Thanks to publishing build cache on
-[cache.dasharo.com](https://cache.dasharo.com/yocto/dts/) time needed to finish
-the process should be significantly decreased.
+Thanks to publishing the build cache on
+[cache.dasharo.com](https://cache.dasharo.com/yocto/dts/) the time needed to
+finish the process should be significantly decreased.
 
 ### Prerequisites
 
@@ -127,14 +127,14 @@ git clone https://github.com/Dasharo/meta-dts.git
 
 ### Build
 
-From `yocto` directory run:
+From `yocto` directory, run:
 
 ```shell
 SHELL=/bin/bash kas-container build meta-dts/kas.yml
 ```
 
-Image build takes time, so be patient and after build's finish you should see
-something similar to (the exact tasks numbers may differ):
+Image build takes time, so be patient, and the build's finished, you should see
+something similar to (tasks number may differ):
 
 ```shell
 Initialising tasks: 100% |###########################################################################################| Time: 0:00:01
@@ -143,8 +143,8 @@ NOTE: Executing Tasks
 NOTE: Tasks Summary: Attempted 2532 tasks of which 2524 didn't need to be rerun and all succeeded.
 ```
 
-Using cache is enabled in `kas/cache.yml` file and can be disabled by removing
-content of that file.
+Using the cache is enabled in `kas/cache.yml` file and can be disabled by
+removing content of that file.
 
 ```bash
 cat kas/cache.yml
@@ -182,9 +182,9 @@ Device     Boot  Start    End Sectors  Size Id Type
 /dev/sdx2       139264 186667   47404 23,2M 83 Linux
 ```
 
-in this case the device name is `/dev/sdx` **but be aware, in next steps
-replace `/dev/sdx` with right device name on your platform or else you can
-damage your system!.**
+In this case the device name is `/dev/sdx`, **but be aware, in the next steps,
+replace `/dev/sdx` with the right device name on your platform, or else you can
+damage your system!**
 
 * From where you ran image build type.
 
@@ -196,22 +196,22 @@ sudo umount /dev/sdx*
 cd build/tmp/deploy/images/genericx86-64
 ```
 
-Here the file `dts-base-image-genericx86-64.wic.gz` should be available which
-is the image of DTS. To flash image you can use the same command as showed in
-[running section](#launching-dts_1), just change the file name.
+Here the file `dts-base-image-genericx86-64.wic.gz` should be available, which
+is the image of DTS. To flash image, you can use the same command shown in
+[running section](#launching-dts_1). Just change the file name.
 
 * Boot the platform.
 
 ## Disabling Secure Boot
 
-Any procedure which affects the firmware flashing should be preceded by
-controlling the Secure Boot status and if it is turned on, turning it off. The
-enabled Secure Boot will not only prevent you from operating on the firmware,
-but you will also not be able to launch DTS.
+Any procedure affecting the firmware flashing should be preceded by controlling
+the Secure Boot status and if it is turned on, turning it off. The enabled
+Secure Boot will not only prevent you from operating on the firmware, but you
+will also not be able to launch DTS.
 
 To check the Secure Boot state:
 
-1. Turn off the station, on which you want to test the Dasharo firmware.
+1. Turn off the station on which you want to test the Dasharo firmware.
 1. Turn the station on and go to the next step immediately.
 1. Hold the `BIOS SETUP KEY` to enter the `BIOS MENU`.
 1. Localize and enter the `Secure Boot` menu using the arrow keys and Enter.
@@ -226,7 +226,7 @@ You could confirm that by repeating steps 3 - 5.
 
 ## Features
 
-This section describes functionality of Dasharo Tools Suite. These are:
+This section describes the functionality of the Dasharo Tools Suite. These are:
 
 * [Dasharo zero-touch initial deployment](#dasharo-zero-touch-initial-deployment),
 * [HCL Report](#hcl-report),
@@ -239,16 +239,24 @@ This section describes functionality of Dasharo Tools Suite. These are:
 
 ### Dasharo zero-touch initial deployment
 
-DTS can be use to flash Dasharo firmware on your hardware. To achieve this, boot
-DTS, choose option number `2`. After creating
+DTS can be used to flash Dasharo firmware on your hardware. To achieve this,
+boot DTS, choose option number `2`. After creating
 [report](../glossary.md#dasharo-hardware-compatibility-list-report) with
-firmware dump as backup, type `p` to confirm installation of Dasharo firmware.
+firmware dump as backup, type `p` to confirm the installation of Dasharo
+firmware.
 
-Procedure execution ends on automatically power off. After restarting the
-platform, you can enjoy the basic version of Dasharo which we provide for given
-hardware.
+Next you will be asked two questions to confirm flashing. The first will be
+displayed with the detected information about the device you are using DTS on.
+The second will also provide the hash of Dasharo components which will then be
+used for flashing. You can compare them with the values listed in the supported
+hardware section on docs.dasharo.com. Both these questions can be accepted by
+typing `Y`.
 
-This feature is supported on following platforms:
+Procedure execution ends automatically on the reboot of the platform (unless it
+requires otherwise). After restarting the device, you can enjoy the basic
+version of Dasharo, which we provide for given hardware.
+
+This feature is supported on the following platforms:
 
 * ASUS KGPE-D16,
 * Dell OptiPlex 7010/9010,
@@ -258,10 +266,10 @@ This feature is supported on following platforms:
 
 ### HCL Report
 
-DTS allows to generate a package with logs containing hardware information. To
-create one, choose option number 1 and check out the disclaimer. If you would
-like to send the report to our servers, please remember about connecting the
-ethernet cable. More information can be found in
+DTS allows the generation of a package with logs containing hardware
+information. To create one, choose option number 1 and check out the disclaimer.
+If you would like to send the report to our servers, please remember about
+connecting the ethernet cable. More information can be found in
 [glossary](../glossary.md#dasharo-hardware-compatibility-list-report).
 
 ![](./images/dts-hcl-run.png)
@@ -272,7 +280,7 @@ Please note DTS HCL Report assumes that your chipset is already supported by
 flashrom. There are also other false negative errors and unknowns, which we
 trying to fix to improve user experience.
 
-Always check `results` file to confirm quality of your HCL report. Sample
+Always check `results` file to confirm the quality of your HCL report. Sample
 content of such file may look as follows:
 
 ```text
@@ -309,28 +317,29 @@ Legend:
 [ERROR]    Error during getting data
 ```
 
-Please report all errors experienced while performing dump to
+Please report all errors experienced while performing a dump to
 [dasharo-issues](https://github.com/Dasharo/dasharo-issues) repository.
 
 #### BIOS backup
 
 One of the key components of HCL Report is your BIOS backup. To prepare BIOS
-backup of your platform simply run HCL Report and decide if you would like to
+backup of your platform, simply run HCL Report and decide if you would like to
 contribute information about your hardware configuration.
 
-Please consider following options depending on your situation:
+Please consider the following options depending on your situation:
 
-* **YES** - If you decided to contribute you can always [get back to
+* **YES** - If you decide to contribute, you can always [get back to
   us](https://www.dasharo.com/pages/contact/) and ask about BIOS backup, which
   we will provide after simple verification that you are the owner of the
   hardware.
-* **NO (default)** - If you decided to not contribute your situation depends on
-  boot method you used to execute DTS:
-    - **Network Boot** - please note that Dasharo booted over iPXE assumes no storage
-      available, so report and your BIOS backup are stored in temporary memory
-      and will not be available after reboot. Please make sure to move HCL report
-      to not volatile storage. This can be done using option `9) Shell`
-    - **USB Boot** - HCL report and BIOS backup are saved to USB storage root
+* **NO (default)** - If you decide to not contribute, your situation depends on
+  the boot method you used to execute DTS:
+    - **Network Boot** - please note that Dasharo booted over iPXE assumes no
+      storage available, so the report, and your BIOS backup are stored in
+      temporary memory and will not be available after reboot. Please make sure
+      to move HCL Report to not volatile storage. This can be done using option
+      `9) Shell`,
+    - **USB Boot** - HCL Report and BIOS backup are saved to USB storage root
       directory.
 
 ### Firmware update
@@ -338,7 +347,7 @@ Please consider following options depending on your situation:
 Within DTS, you may use the `flashrom` and `fwupdmgr` utilities to update,
 downgrade, or reinstall your firmware.
 
-To update your firmware to the latest version first choose option number 9 to
+To update your firmware to the latest version, first choose option number 9 to
 drop to Shell and run:
 
 ```bash
@@ -348,8 +357,8 @@ fwupdmgr update
 
 ### EC transition
 
-DTS allows to perform full Embedded Controller firmware transition from the
-proprietary vendor EC firmware, to the Dasharo EC firmware. Currently, this
+DTS allows performing full Embedded Controller firmware transition from the
+proprietary vendor EC firmware to the Dasharo EC firmware. Currently, this
 functionality is supported on the [NovaCustom
 NS5x/NS7x](/variants/novacustom_ns5x_tgl/releases/)) and [NovaCustom
 NV4x](/variants/novacustom_nv4x_tgl/releases/) only.
@@ -537,20 +546,20 @@ version. This is how we can achieve that.
 ### Additional features
 
 The section below presents a list of functionalities added to DTS, which were
-developed at the request of the community, and which do not necessarily relate
+developed at the community's request and which do not necessarily relate
 strictly to Dasharo.
 
 #### Run commands from iPXE shell
 
-There is a possibility to execute the bash script after Linux startup by passing
-it from the iPXE shell. Every script placed in `/sbin/ipxe-commands` will be
-executed automatically after startup.
+It is possible to execute the bash script after Linux startup by passing it from
+the iPXE shell. Every script placed in `/sbin/ipxe-commands` will be executed
+automatically after startup.
 
-Here is simple instruction on how to use that feature.
+Here is a simple instruction on how to use that feature.
 
-* Run the HTTP server in the directory which contains DTS base image. If you
-build it by yourself, then it should be `meta-dts` subdirectory:
-`build/tmp/deploy/images/genericx86-64`.
+* Run the HTTP server in the directory which contains the DTS base image. If you
+  build it by yourself, then it should be the `meta-dts` subdirectory:
+  `build/tmp/deploy/images/genericx86-64`.
 
 The easiest way to start an HTTP server is using `http.server` python module.
 
@@ -558,9 +567,9 @@ The easiest way to start an HTTP server is using `http.server` python module.
 $ python3 -m http.server 9000
 ```
 
-* Create `dts.ipxe` bootchain file in directory where you have a running HTTP
-server. That file should have similar content (you need to enter IP of your
-host machine in a local network).
+* Create a `dts.ipxe` bootchain file in a directory where you have an HTTP
+  server. That file should have similar content (you need to enter the IP of
+  your host machine in a local network).
 
 ```bash
 #!ipxe
@@ -573,7 +582,7 @@ boot
 
 * Copy your `custom-script` script in this same directory.
 
-* Enter the iPXE shell on your device and load `dts.ipxe` chainboot file.
+* Enter the iPXE shell on your device and load `dts.ipxe` bootchain file.
 
 ```bash
 iPXE> dhcp

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -233,7 +233,9 @@ This section describes functionality of Dasharo Tools Suite. These are:
 * [Firmware update](#firmware-update),
 * [EC Transition](#ec-transition),
 * [EC update](#ec-update),
-* [Run commands from iPXE shell](#ipxe-commands).
+* [additional features](#additional-features),
+    - [run commands from iPXE shell](#run-commands-from-ipxe-shell),
+    - [run DTS using VentoyOS](#run-dts-using-ventoyos).
 
 ### Dasharo zero-touch initial deployment
 
@@ -532,7 +534,13 @@ version. This is how we can achieve that.
   version: 2022-08-31_cbff21b
   ```
 
-### Run commands from iPXE shell
+### Additional features
+
+The section below presents a list of functionalities added to DTS, which were
+developed at the request of the community, and which do not necessarily relate
+strictly to Dasharo.
+
+#### Run commands from iPXE shell
 
 There is a possibility to execute the bash script after Linux startup by passing
 it from the iPXE shell. Every script placed in `/sbin/ipxe-commands` will be
@@ -581,3 +589,17 @@ http://192.168.4.98:9000/custom-script... ok
 
 Now your `custom-script` script should be copied to DTS rootfs as
 `ipxe-commands` and will be executed after boot.
+
+#### Run DTS using VentoyOS
+
+Starting from version [v1.1.1](./releases.md#v111), we provide also an ISO
+formatted image. Thanks to that, it can be used with VentoyOS[1]. As for now the
+following limitations are known.
+
+* VentoyOS needs to be started in UEFI mode.
+* Nothing can be saved on root file system, as VentoyOS boots systems in
+  read-only mode.
+
+Please let us know if you started DTS using VentoyOS and have additional
+information for us. You can share them on [Dasharo Matrix
+Workspace](https://matrix.to/#/#dasharo:matrix.org).

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -47,7 +47,8 @@ platform:
 
 * Dasharo device with DTS functionality integrated,
 * wired network connection,
-* [Secure Boot disabled](#disabling-secure-boot).
+* [Secure Boot disabled](#disabling-secure-boot),
+* disabled BIOS lock feature (if device is already flashed with Dasharo).
 
 #### Launching DTS
 
@@ -71,6 +72,7 @@ platform:
 * USB stick (at least 2GB),
 * wired network connection,
 * [Secure Boot disabled](#disabling-secure-boot),
+* disabled BIOS lock feature (if device is already flashed with Dasharo),
 * latest image from [releases](./releases.md) section.
 
 #### Launching DTS

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -16,7 +16,7 @@ that it boots on the following platforms:
 * Protectli FW6/VP46xx.
 
 <span style="color:red">
-Please do not use DTS to deploy Dasharo on MSI PRO Z690-A (WIFI) DDR5;
+Please do not use DTS v1.1.0 to deploy Dasharo on MSI PRO Z690-A (WIFI) DDR5;
 otherwise, you will brick your hardware. There are at least two bugs that have
 to be fixed before it is possible:
 

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -231,7 +231,7 @@ This section describes functionality of Dasharo Tools Suite. These are:
 * [Dasharo zero-touch initial deployment](#dasharo-zero-touch-initial-deployment),
 * [HCL Report](#hcl-report),
 * [Firmware update](#firmware-update),
-* [EC Transition](#ec-transition),
+* [EC transition](#ec-transition),
 * [EC update](#ec-update),
 * [additional features](#additional-features),
     - [run commands from iPXE shell](#run-commands-from-ipxe-shell),
@@ -309,7 +309,7 @@ Legend:
 [ERROR]    Error during getting data
 ```
 
-Please report all errors exerienced while performing dump to
+Please report all errors experienced while performing dump to
 [dasharo-issues](https://github.com/Dasharo/dasharo-issues) repository.
 
 #### BIOS backup
@@ -346,13 +346,13 @@ fwupdmgr refresh
 fwupdmgr update
 ```
 
-### EC Transition
+### EC transition
 
 DTS allows to perform full Embedded Controller firmware transition from the
-proprietary vendor EC firmware, to the open-source Dasharo EC firmware.
-Currently, this functionality is supported on the
-[NovaCustom NS5x/NS7x](/variants/novacustom_ns5x_tgl/releases/)) and
-[NovaCustom NV4x](/variants/novacustom_nv4x_tgl/releases/) only.
+proprietary vendor EC firmware, to the Dasharo EC firmware. Currently, this
+functionality is supported on the [NovaCustom
+NS5x/NS7x](/variants/novacustom_ns5x_tgl/releases/)) and [NovaCustom
+NV4x](/variants/novacustom_nv4x_tgl/releases/) only.
 
 To perform EC transition, make sure you are
 [running DTS version v1.0.2 or higher](#running) and follow these steps:

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -225,6 +225,7 @@ This section describes functionality of Dasharo Tools Suite. These are:
 * [Firmware update](#firmware-update)
 * [EC Transition](#ec-transition)
 * [EC update](#ec-update)
+* [Run commands from iPXE shell](#ipxe-commands)
 
 ### Dasharo zero-touch initial deployment
 
@@ -522,3 +523,53 @@ version. To properly update it, follow these steps:
   board: clevo/ns50mu
   version: 2022-08-31_cbff21b
   ```
+
+### Run commands from iPXE shell
+
+There is a possibility to execute the bash script after Linux startup by passing
+it from the iPXE shell. Every script placed in `/sbin/ipxe-commands` will be
+executed automatically after startup.
+
+Here is simple instruction on how to use that feature:
+
+- Run the HTTP server in the directory which contains DTS base image. If you
+build it by yourself, then it should be `meta-dts` subdirectory:
+`build/tmp/deploy/images/genericx86-64`
+
+The easiest way to start an HTTP server is using `http.server` python module:
+
+```bash
+$ python3 -m http.server 9000
+```
+
+- Create `dts.ipxe` bootchain file in directory where you have a running HTTP
+server. That file should have similar content (you need to enter IP of your
+host machine in a local network):
+
+```bash
+#!ipxe
+#
+kernel http://<YOUR_IP>:9000/bzImage root=/dev/nfs initrd=http://<YOUR_IP>:9000/dts-base-image-genericx86-64.cpio.gz
+initrd http://<YOUR_IP>:9000/dts-base-image-genericx86-64.cpio.gz
+module http://<YOUR_IP>:9000/ipxe-commands /sbin/ipxe-commands mode=755
+boot
+```
+
+- Copy your `ipxe-commands` script in this same directory
+
+- Enter the iPXE shell on your device and load `dts.ipxe` chainboot file:
+
+```bash
+iPXE> dhcp
+Configuring (net0 00:0d:b9:4b:49:60)...... ok
+iPXE> route
+net0: 192.168.4.126/255.255.255.0 gw 192.168.4.1
+iPXE> chain http://192.168.4.98:9001/dts.ipxe
+http://192.168.4.98:9001/dts.ipxe... ok
+http://192.168.4.98:9001/bzImage... ok
+http://192.168.4.98:9001/dts-base-image-genericx86-64.cpio.gz... ok
+http://192.168.4.98:9000/ipxe-commands... ok
+```
+
+Now your `ipxe-commands` script should be copied to DTS rootfs and will be
+executed after boot

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -551,11 +551,11 @@ host machine in a local network):
 #
 kernel http://<YOUR_IP>:9000/bzImage root=/dev/nfs initrd=http://<YOUR_IP>:9000/dts-base-image-genericx86-64.cpio.gz
 initrd http://<YOUR_IP>:9000/dts-base-image-genericx86-64.cpio.gz
-module http://<YOUR_IP>:9000/ipxe-commands /sbin/ipxe-commands mode=755
+module http://<YOUR_IP>:9000/custom-script /sbin/ipxe-commands mode=755
 boot
 ```
 
-* Copy your `ipxe-commands` script in this same directory
+* Copy your `custom-script` script in this same directory
 
 * Enter the iPXE shell on your device and load `dts.ipxe` chainboot file:
 
@@ -564,12 +564,12 @@ iPXE> dhcp
 Configuring (net0 00:0d:b9:4b:49:60)...... ok
 iPXE> route
 net0: 192.168.4.126/255.255.255.0 gw 192.168.4.1
-iPXE> chain http://192.168.4.98:9001/dts.ipxe
-http://192.168.4.98:9001/dts.ipxe... ok
-http://192.168.4.98:9001/bzImage... ok
-http://192.168.4.98:9001/dts-base-image-genericx86-64.cpio.gz... ok
-http://192.168.4.98:9000/ipxe-commands... ok
+iPXE> chain http://192.168.4.98:9000/dts.ipxe
+http://192.168.4.98:9000/dts.ipxe... ok
+http://192.168.4.98:9000/bzImage... ok
+http://192.168.4.98:9000/dts-base-image-genericx86-64.cpio.gz... ok
+http://192.168.4.98:9000/custom-script... ok
 ```
 
-Now your `ipxe-commands` script should be copied to DTS rootfs and will be
-executed after boot
+Now your `custom-script` script should be copied to DTS rootfs as
+`ipxe-commands` and will be executed after boot.

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -9,6 +9,8 @@ that it boots on the following platforms:
 * Dell OptiPlex 7010/9010,
 * MSI PRO Z690-A DDR4 ([test
   report](https://docs.google.com/spreadsheets/d/16wokQYhtS7XA1DQC3Om7FY-IImG6SZisGK7NnzyRGVY/edit#gid=0&range=A75)),
+* MSI PRO Z690-A DDR5 ([test
+  report](https://docs.google.com/spreadsheets/d/16wokQYhtS7XA1DQC3Om7FY-IImG6SZisGK7NnzyRGVY/edit#gid=777478871&range=A81)),
 * NovaCustom NV4x ([test
   report](https://docs.google.com/spreadsheets/d/1LOXY9HCu-fMitkYwX08iLsQdSNenzyU0LnMdVbZB5Do/edit#gid=536764189&range=A161)),
 * NovaCustom NS5x/7x ([test
@@ -164,6 +166,36 @@ local_conf_header:
     LOCAL_PREMIRROR_SERVER ?= "cache.dasharo.com"
     PROJECT_NAME ?= "yocto/dts"
 ```
+
+#### Build image with UEFI Secure Boot support
+
+From `yocto` directory run:
+
+```shell
+SHELL=/bin/bash kas-container build meta-dts/kas-uefi-sb.yml
+```
+
+Image build takes time, so be patient and after build's finish you should see
+something similar to (the exact tasks numbers may differ):
+
+```shell
+Initialising tasks: 100% |###########################################################################################| Time: 0:00:04
+Checking sstate mirror object availability: 100% |###################################################################| Time: 0:00:03
+Sstate summary: Wanted 892 Local 672 Mirrors 212 Missed 8 Current 1560 (99% match, 99% complete)
+NOTE: Executing Tasks
+NOTE: Tasks Summary: Attempted 5860 tasks of which 5841 didn't need to be rerun and all succeeded.
+```
+
+Image created with `kas-uefi-sb.yml` configuration file enable integration of
+UEFI Secure Boot into DTS using
+[meta-secure-core](https://github.com/jiazhang0/meta-secure-core/). Building the
+image allow to prepare a PoC version with [uses sample
+keys](https://github.com/jiazhang0/meta-secure-core/tree/master/meta-efi-secure-boot#sample-keys)
+which by no mean should used in production. For user keys the script
+[create-user-key-store.sh](https://github.com/jiazhang0/meta-secure-core/blob/master/meta-signing-key/scripts/create-user-key-store.sh
+can be used but it was not tested yet. Quick start with instructions on how to
+use image are described in
+[meta-efi-secure-boot](https://github.com/jiazhang0/meta-secure-core/tree/master/meta-efi-secure-boot#quick-start-for-the-first-boot).
 
 ### Flash
 

--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -220,11 +220,11 @@ You could confirm that by repeating steps 3 - 5.
 
 This section describes functionality of Dasharo Tools Suite. These are:
 
-* Dasharo zero-touch initial deployment
-* HCL Report,
-* Firmware update,
-* EC Transition,
-* EC update.
+* [Dasharo zero-touch initial deployment](#dasharo-zero-touch-initial-deployment)
+* [HCL Report](#hcl-report)
+* [Firmware update](#firmware-update)
+* [EC Transition](#ec-transition)
+* [EC update](#ec-update)
 
 ### Dasharo zero-touch initial deployment
 

--- a/docs/dasharo-tools-suite/overview.md
+++ b/docs/dasharo-tools-suite/overview.md
@@ -5,19 +5,19 @@
 ## Overview
 
 Dasharo Tools Suite (DTS) is a set of tools running in a minimal Linux
-environment, with a goal of deploying, updating and maintaining firmware on
-Dasharo supported devices. For example, it can be used to update the firmware
-on a device or run initial deployment, even when no OS is currently installed.
+environment to deploy, update, and maintain firmware on Dasharo-supported
+devices. For example, it can be used to update the firmware on a device or run
+the initial deployment, even when no OS is currently installed.
 
 * [Releases](releases.md) - groups information about all releases.
 * [Documentation](documentation.md) - describes DTS functionality and
-    information how to run it.
+    information on how to run it.
 
 ## Reporting issues
 
 Thank you for using Dasharo Tools Suite. If you have encountered any problems
-with this system, or would like to provide feedback for us - please open an
-issue on [Dasharo
+with this system or would like to provide feedback for us - please open an issue
+on [Dasharo
 issues](https://github.com/Dasharo/dasharo-issues/issues?q=is%3Aopen+is%3Aissue+label%3ADasharoToolsSuite).
 
 And if you have already used this system and would be interested in supporting

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -13,25 +13,36 @@ Process](../dev-proc/standard-release-process.md).
 
 [newsletter]: https://newsletter.3mdeb.com/subscription/ttzqCq9fy
 
-## v1.1.1
+## v1.1.1 - 2023-02-17
 
 ### Images
 
-* [USB bootable DTS v1.1.1 image](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz-TBD)
-* [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256-TBD)
-* [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256.sig-TBD)
-* [DTS v1.1.1 ISO image](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso-TBD)
-* [sha256 ISO](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256-TBD)
-* [sha256.sig ISO](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256.sig-TBD)
+* [USB bootable DTS v1.1.1 image](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz)
+* [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256)
+* [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256.sig)
+* [DTS v1.1.1 ISO image](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso)
+* [sha256 ISO](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256)
+* [sha256.sig ISO](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256.sig)
 
   See how to verify hash and signature on [this
   video](https://youtu.be/RF-NYcZM9JI). It works the same way with ISO image.
 
 ### Changelog
 
-* TBD
+* Blocked Dasharo zero-touch initial deployment on MSI PRO Z690-A (WIFI) DDR5.
+* Blocked Dasharo zero-touch initial deployment on platforms where Dasharo
+  firmware was detected.
+* Added couple QoL improvements for Dasharo zero-touch initial deployment:
+    - added platform verification step (show detected device information),
+    - added firmware verification step (show hash of using binary),
+    - added progress bar on first instructions,
+    - used reboot as default behavior after successful flashing.
+* Added improvements for HCL report.
+* Added DTS ISO format image, and documentation about
+  [VentoyOS](./documentation.md#run-dts-using-ventoyos) usage.
+* Improved `README` of the `meta-dts` repository.
 
-## v1.1.0
+## v1.1.0 - 2022-11-02
 
 ### Images
 
@@ -64,7 +75,7 @@ Process](../dev-proc/standard-release-process.md).
   [boot.dasharo.com](https://boot.dasharo.com/dts/).
 * Sharing build cache on [cache.dasharo.com](https://cache.dasharo.com/yocto/dts/).
 
-## v1.0.2
+## v1.0.2 - 2022-10-19
 
 ### Images
 
@@ -90,7 +101,7 @@ Process](../dev-proc/standard-release-process.md).
 * Enabled GOOGLE_MEMCONSOLE_COREBOOT kernel configuration to ease getting
   firmware logs.
 
-## v1.0.1
+## v1.0.1 - 2022-09-02
 
 ### Images
 
@@ -109,7 +120,7 @@ Process](../dev-proc/standard-release-process.md).
   NovaCustom NS5x/7x.
 * First public release: [meta-dts-ce](https://github.com/Dasharo/meta-dts-ce).
 
-## v1.0.0
+## v1.0.0 - 2022-08-09
 
 ### Images
 
@@ -122,7 +133,7 @@ Process](../dev-proc/standard-release-process.md).
   sha256sum -c [sha256 file]
   ```
 
-### Changelogsystem76_ectool
+### Changelog
 
 * Added auto-login functionality.
 * Added user menu.

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -17,19 +17,27 @@ Process](../dev-proc/standard-release-process.md).
 
 ### Images
 
-* [USB bootable DTS v1.1.1 image](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz)
-* [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256)
-* [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256.sig)
-* [DTS v1.1.1 ISO image](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso)
-* [sha256 ISO](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256)
-* [sha256.sig ISO](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256.sig)
+[USB bootable DTS v1.1.1 image][USB_DTS_v1.1.1]{ .md-button }
+[sha256][USB_DTS_sha_v1.1.1]{ .md-button }
+[sha256.sig][USB_DTS_sig_v1.1.1]{ .md-button }
+[DTS v1.1.1 ISO image][ISO_DTS_v1.1.1]{ .md-button }
+[sha256 ISO][ISO_DTS_sha_v1.1.1]{ .md-button }
+[sha256.sig ISO][ISO_DTS_sig_v1.1.1]{ .md-button }
+
+[USB_DTS_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz)
+[USB_DTS_sha_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256)
+[USB_DTS_sig_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256.sig)
+[ISO_DTS_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso)
+[ISO_DTS_sha_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256)
+[ISO_DTS_sig_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256.sig)
 
   See how to verify hash and signature on [this
   video](https://youtu.be/RF-NYcZM9JI). It works the same way with ISO image.
 
 ### Changelog
 
-* Fixed Dasharo zero-touch initial deployment on MSI PRO Z690-A (WIFI) DDR5.
+* Fixed Dasharo zero-touch initial deployment on MSI PRO Z690-A, added DDR5
+  target with dedicated firmware.
 * Blocked Dasharo zero-touch initial deployment on platforms where Dasharo
   firmware was detected.
 * Added couple QoL improvements for Dasharo zero-touch initial deployment:
@@ -41,17 +49,22 @@ Process](../dev-proc/standard-release-process.md).
 * Added DTS ISO format image, and documentation about
   [VentoyOS](./documentation.md#run-dts-using-ventoyos) usage.
 * Improved `README` of the `meta-dts` repository.
+* Added service to run shell [commands from
+  iPXE](./documentation.md#run-commands-from-ipxe-shell).
+* Added instructions for building PoC image with [enabled UEFI Secure
+  Boot](./documentation.md#build-image-with-uefi-secure-boot-support) support.
 
 ## v1.1.0 - 2022-11-02
 
 ### Images
 
-* [USB bootable DTS v1.1.0 image](https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz)
-* [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256)
-* [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256.sig)
+[USB bootable DTS v1.1.0 image][USB_DTS_v1.1.0]{ .md-button }
+[sha256][USB_DTS_sha_v1.1.0]{ .md-button }
+[sha256.sig][USB_DTS_sig_v1.1.0]{ .md-button }
 
-  See how to verify hash and signature on [this
-  video](https://youtu.be/RF-NYcZM9JI).
+[USB_DTS_v1.1.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz)
+[USB_DTS_sha_v1.1.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256)
+[USB_DTS_sig_v1.1.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256.sig)
 
 ### Changelog
 
@@ -79,9 +92,13 @@ Process](../dev-proc/standard-release-process.md).
 
 ### Images
 
-* [USB bootable DTS v1.0.2 image](https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz)
-* [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256)
-* [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256.sig)
+[USB bootable DTS v1.0.2 image][USB_DTS_v1.0.2]{ .md-button }
+[sha256][USB_DTS_sha_v1.0.2]{ .md-button }
+[sha256.sig][USB_DTS_sig_v1.0.2]{ .md-button }
+
+[USB_DTS_v1.0.2]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz)
+[USB_DTS_sha_v1.0.2]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256)
+[USB_DTS_sig_v1.0.2]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256.sig)
 
   See how to verify hash and signature on [this
   video](https://youtu.be/oTx2iStxXOE).
@@ -105,9 +122,13 @@ Process](../dev-proc/standard-release-process.md).
 
 ### Images
 
-* [USB bootable DTS v1.0.1 image](https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz)
-* [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz.sha256)
-* [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz.sha256.sig)
+[USB bootable DTS v1.0.1 image][USB_DTS_v1.0.1]{ .md-button }
+[sha256][USB_DTS_sha_v1.0.1]{ .md-button }
+[sha256.sig][USB_DTS_sig_v1.0.1]{ .md-button }
+
+[USB_DTS_v1.0.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz)
+[USB_DTS_sha_v1.0.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz.sha256)
+[USB_DTS_sig_v1.0.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz.sha256.sig)
 
   See how to verify hash and signature on [this video.](https://youtu.be/oTx2iStxXOE)
 
@@ -124,8 +145,11 @@ Process](../dev-proc/standard-release-process.md).
 
 ### Images
 
-* [USB bootable DTS v1.0.0 image](https://3mdeb.com/open-source-firmware/DTS/v1.0.0/dts-base-image-ce-v1.0.0.wic.gz)
-* [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.0.0/dts-base-image-ce-v1.0.0.wic.gz.sha256)
+[USB bootable DTS v1.0.0 image][USB_DTS_v1.0.0]{ .md-button }
+[sha256][USB_DTS_sha_v1.0.0]{ .md-button }
+
+[USB_DTS_v1.0.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.0/dts-base-image-ce-v1.0.0.wic.gz)
+[USB_DTS_sha_v1.0.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.0/dts-base-image-ce-v1.0.0.wic.gz.sha256)
 
   ```bash
   # assuming all files have been downloaded to the same directory without

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -27,23 +27,23 @@ For details about our release process please read
 
 * Added [Dasharo zero-touch
   initial deployment](./documentation.md#dasharo-zero-touch-initial-deployment)
-  for couple of supported platforms
-* Added multiple HCL report improvements, e.g. dump information about TPM, ME
-* Refactored Dasharo Tools Suite [documentation](./overview.md)
-* Added possibility to rollback using firmware dumped in HCL report
+  for couple of supported platforms.
+* Added multiple HCL report improvements, e.g. dump information about TPM, ME.
+* Refactored Dasharo Tools Suite [documentation](./overview.md).
+* Added possibility to rollback using firmware dumped in HCL report.
 * Added documentation about [building Dasharo Tools Suite
-  image](./documentation.md#building)
-* Added Github Actions to automate new version building
+  image](./documentation.md#building).
+* Added Github Actions to automate new version building.
 * Added new tools: cbfstool, cbmem, futil, intelmetool (all from [Dasharo
   coreboot fork](https://github.com/Dasharo/coreboot/tree/coreboot-utils)),
   [binwalk](https://github.com/ReFirmLabs/binwalk),
   [uefi-firmware-parser](github.com/theopolis/uefi-firmware-parser),
-  [mei-amt-check](github.com/mjg59/mei-amt-check)
+  [mei-amt-check](github.com/mjg59/mei-amt-check).
 * Updated flashrom to version
-  [dasharo-v1.2.2](https://github.com/Dasharo/flashrom/tree/dasharo-v1.2.2)
+  [dasharo-v1.2.2](https://github.com/Dasharo/flashrom/tree/dasharo-v1.2.2).
 * Deploying iPXE boot artifacts on
-  [boot.dasharo.com](https://boot.dasharo.com/dts/)
-* Sharing build cache on [cache.dasharo.com](https://cache.dasharo.com/yocto/dts/)
+  [boot.dasharo.com](https://boot.dasharo.com/dts/).
+* Sharing build cache on [cache.dasharo.com](https://cache.dasharo.com/yocto/dts/).
 
 ## v1.0.2
 
@@ -59,16 +59,16 @@ For details about our release process please read
 
 * Added new vendor specific menu entry which is displayed only on supported
   platforms, for now NovaCustom menu was added for NovaCustom NV4x and
-  NovaCustom NS5x/7x laptops
-* DTS version is now printed in the main menu
+  NovaCustom NS5x/7x laptops.
+* DTS version is now printed in the main menu.
 * `ec_transition` script now supports NovaCustom NV4x laptops and automatically
   download firmware used for transition both for NovaCustom NV4x NV4x and
   NovaCustom NS5x/7x laptopts, [firmware
-  transition](documentation.md#ec-transition) documentation is updated
+  transition](documentation.md#ec-transition) documentation is updated.
 * Added kernel configuration to silence terminal logs by default (change
-  loglevel to 1)
+  loglevel to 1).
 * Enabled GOOGLE_MEMCONSOLE_COREBOOT kernel configuration to ease getting
-  firmware logs
+  firmware logs.
 
 ## v1.0.1
 
@@ -82,10 +82,10 @@ For details about our release process please read
 
 ### Changelog
 
-* Added system76_ectool to enable Embedded Controller [firmware updating](./documentation.md#ec-update)
+* Added system76_ectool to enable Embedded Controller [firmware updating](./documentation.md#ec-update).
 * Added ec_transition script which helps with full Dasharo/Embedded Controller
-  [firmware transition](./documentation.md#ec-transition) for NovaCustom NS5x/7x
-* First public release: [meta-dts-ce](https://github.com/Dasharo/meta-dts-ce)
+  [firmware transition](./documentation.md#ec-transition) for NovaCustom NS5x/7x.
+* First public release: [meta-dts-ce](https://github.com/Dasharo/meta-dts-ce).
 
 ## v1.0.0
 
@@ -102,13 +102,13 @@ For details about our release process please read
 
 ### Changelog
 
-* Auto-login functionality
-* User menu
+* Added auto-login functionality.
+* Added user menu.
 * [Dasharo HCL Report](../glossary.md#dasharo-hardware-compatibility-list-report)
   which add the ability to automatically dump device information and send it to
-  3mdeb servers
+  3mdeb servers.
 * Possibility to manually [update the Dasharo
-  firmware](./documentation.md#firmware-update)
-* [Bootable via iPXE](./documentation.md#bootable-over-network)
-* [Bootable via USB](./documentation.md#bootable-usb-stick)
-* Tested on NovaCustom NV4x, Dell OptiPlex 7010/9010
+  firmware](./documentation.md#firmware-update).
+* [Bootable via iPXE](./documentation.md#bootable-over-network).
+* [Bootable via USB](./documentation.md#bootable-usb-stick).
+* Tested on NovaCustom NV4x, Dell OptiPlex 7010/9010.

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -29,7 +29,7 @@ Process](../dev-proc/standard-release-process.md).
 
 ### Changelog
 
-* Blocked Dasharo zero-touch initial deployment on MSI PRO Z690-A (WIFI) DDR5.
+* Fixed Dasharo zero-touch initial deployment on MSI PRO Z690-A (WIFI) DDR5.
 * Blocked Dasharo zero-touch initial deployment on platforms where Dasharo
   firmware was detected.
 * Added couple QoL improvements for Dasharo zero-touch initial deployment:

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -27,7 +27,7 @@ For details about our release process please read
 
 * Added [Dasharo zero-touch
   initial deployment](./documentation.md#dasharo-zero-touch-initial-deployment)
-  for couple of supported platform
+  for couple of supported platforms
 * Added multiple HCL report improvements, e.g. dump information about TPM, ME
 * Refactored Dasharo Tools Suite [documentation](./overview.md)
 * Added possibility to rollback using firmware dumped in HCL report

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -13,7 +13,7 @@ Process](../dev-proc/standard-release-process.md).
 
 [newsletter]: https://newsletter.3mdeb.com/subscription/ttzqCq9fy
 
-## v1.1.1 - 2023-02-17
+## v1.1.1 - 2023-02-20
 
 ### Images
 

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -20,16 +20,17 @@ Process](../dev-proc/standard-release-process.md).
 [USB bootable DTS v1.1.1 image][USB_DTS_v1.1.1]{ .md-button }
 [sha256][USB_DTS_sha_v1.1.1]{ .md-button }
 [sha256.sig][USB_DTS_sig_v1.1.1]{ .md-button }
+
 [DTS v1.1.1 ISO image][ISO_DTS_v1.1.1]{ .md-button }
 [sha256 ISO][ISO_DTS_sha_v1.1.1]{ .md-button }
 [sha256.sig ISO][ISO_DTS_sig_v1.1.1]{ .md-button }
 
-[USB_DTS_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz)
-[USB_DTS_sha_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256)
-[USB_DTS_sig_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256.sig)
-[ISO_DTS_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso)
-[ISO_DTS_sha_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256)
-[ISO_DTS_sig_v1.1.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256.sig)
+[USB_DTS_v1.1.1]: https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz
+[USB_DTS_sha_v1.1.1]: https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256
+[USB_DTS_sig_v1.1.1]: https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256.sig
+[ISO_DTS_v1.1.1]: https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso
+[ISO_DTS_sha_v1.1.1]: https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256
+[ISO_DTS_sig_v1.1.1]: https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256.sig
 
   See how to verify hash and signature on [this
   video](https://youtu.be/RF-NYcZM9JI). It works the same way with ISO image.
@@ -62,9 +63,9 @@ Process](../dev-proc/standard-release-process.md).
 [sha256][USB_DTS_sha_v1.1.0]{ .md-button }
 [sha256.sig][USB_DTS_sig_v1.1.0]{ .md-button }
 
-[USB_DTS_v1.1.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz)
-[USB_DTS_sha_v1.1.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256)
-[USB_DTS_sig_v1.1.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256.sig)
+[USB_DTS_v1.1.0]: https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz
+[USB_DTS_sha_v1.1.0]: https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256
+[USB_DTS_sig_v1.1.0]: https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256.sig
 
 ### Changelog
 
@@ -96,9 +97,9 @@ Process](../dev-proc/standard-release-process.md).
 [sha256][USB_DTS_sha_v1.0.2]{ .md-button }
 [sha256.sig][USB_DTS_sig_v1.0.2]{ .md-button }
 
-[USB_DTS_v1.0.2]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz)
-[USB_DTS_sha_v1.0.2]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256)
-[USB_DTS_sig_v1.0.2]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256.sig)
+[USB_DTS_v1.0.2]: https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz
+[USB_DTS_sha_v1.0.2]: https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256
+[USB_DTS_sig_v1.0.2]: https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256.sig
 
   See how to verify hash and signature on [this
   video](https://youtu.be/oTx2iStxXOE).
@@ -126,9 +127,9 @@ Process](../dev-proc/standard-release-process.md).
 [sha256][USB_DTS_sha_v1.0.1]{ .md-button }
 [sha256.sig][USB_DTS_sig_v1.0.1]{ .md-button }
 
-[USB_DTS_v1.0.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz)
-[USB_DTS_sha_v1.0.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz.sha256)
-[USB_DTS_sig_v1.0.1]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz.sha256.sig)
+[USB_DTS_v1.0.1]: https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz
+[USB_DTS_sha_v1.0.1]: https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz.sha256
+[USB_DTS_sig_v1.0.1]: https://3mdeb.com/open-source-firmware/DTS/v1.0.1/dts-base-image-ce-v1.0.1.wic.gz.sha256.sig
 
   See how to verify hash and signature on [this video.](https://youtu.be/oTx2iStxXOE)
 
@@ -148,8 +149,8 @@ Process](../dev-proc/standard-release-process.md).
 [USB bootable DTS v1.0.0 image][USB_DTS_v1.0.0]{ .md-button }
 [sha256][USB_DTS_sha_v1.0.0]{ .md-button }
 
-[USB_DTS_v1.0.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.0/dts-base-image-ce-v1.0.0.wic.gz)
-[USB_DTS_sha_v1.0.0]: (https://3mdeb.com/open-source-firmware/DTS/v1.0.0/dts-base-image-ce-v1.0.0.wic.gz.sha256)
+[USB_DTS_v1.0.0]: https://3mdeb.com/open-source-firmware/DTS/v1.0.0/dts-base-image-ce-v1.0.0.wic.gz
+[USB_DTS_sha_v1.0.0]: https://3mdeb.com/open-source-firmware/DTS/v1.0.0/dts-base-image-ce-v1.0.0.wic.gz.sha256
 
   ```bash
   # assuming all files have been downloaded to the same directory without

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -1,10 +1,10 @@
 # Release Notes
 
-Following Release Notes describe status of Open Source Software development for
-Dasharo Tools Suite.
+Following Release Notes describe the status of Open Source Software development
+for Dasharo Tools Suite.
 
-For details about our release process please read
-[Dasharo Standard Release Process](../dev-proc/standard-release-process.md).
+For details about our release process, please read [Dasharo Standard Release
+Process](../dev-proc/standard-release-process.md).
 
 <center>
 [Subscribe to Dasharo Tools Suite Newsletter]
@@ -12,6 +12,24 @@ For details about our release process please read
 </center>
 
 [newsletter]: https://newsletter.3mdeb.com/subscription/ttzqCq9fy
+
+## v1.1.1
+
+### Images
+
+* [USB bootable DTS v1.1.1 image](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz-TBD)
+* [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256-TBD)
+* [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.wic.gz.sha256.sig-TBD)
+* [DTS v1.1.1 ISO image](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso-TBD)
+* [sha256 ISO](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256-TBD)
+* [sha256.sig ISO](https://3mdeb.com/open-source-firmware/DTS/v1.1.1/dts-base-image-v1.1.1.iso.sha256.sig-TBD)
+
+  See how to verify hash and signature on [this
+  video](https://youtu.be/RF-NYcZM9JI). It works the same way with ISO image.
+
+### Changelog
+
+* TBD
 
 ## v1.1.0
 
@@ -21,13 +39,14 @@ For details about our release process please read
 * [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256)
 * [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.1.0/dts-base-image-v1.1.0.wic.gz.sha256.sig)
 
-  See how to verify hash and signature on [this video.](https://youtu.be/RF-NYcZM9JI)
+  See how to verify hash and signature on [this
+  video](https://youtu.be/RF-NYcZM9JI).
 
 ### Changelog
 
 * Added [Dasharo zero-touch
   initial deployment](./documentation.md#dasharo-zero-touch-initial-deployment)
-  for couple of supported platforms.
+  for a couple of supported platforms.
 * Added multiple HCL report improvements, e.g. dump information about TPM, ME.
 * Refactored Dasharo Tools Suite [documentation](./overview.md).
 * Added possibility to rollback using firmware dumped in HCL report.
@@ -53,20 +72,21 @@ For details about our release process please read
 * [sha256](https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256)
 * [sha256.sig](https://3mdeb.com/open-source-firmware/DTS/v1.0.2/dts-base-image-ce-v1.0.2.wic.gz.sha256.sig)
 
-  See how to verify hash and signature on [this video.](https://youtu.be/oTx2iStxXOE)
+  See how to verify hash and signature on [this
+  video](https://youtu.be/oTx2iStxXOE).
 
 ### Changelog
 
-* Added new vendor specific menu entry which is displayed only on supported
-  platforms, for now NovaCustom menu was added for NovaCustom NV4x and
+* Added new vendor-specific menu entry, which is displayed only on supported
+  platforms. For now, NovaCustom menu was added for NovaCustom NV4x and
   NovaCustom NS5x/7x laptops.
 * DTS version is now printed in the main menu.
 * `ec_transition` script now supports NovaCustom NV4x laptops and automatically
   download firmware used for transition both for NovaCustom NV4x NV4x and
-  NovaCustom NS5x/7x laptopts, [firmware
+  NovaCustom NS5x/7x laptops, [firmware
   transition](documentation.md#ec-transition) documentation is updated.
 * Added kernel configuration to silence terminal logs by default (change
-  loglevel to 1).
+  `loglevel` to 1).
 * Enabled GOOGLE_MEMCONSOLE_COREBOOT kernel configuration to ease getting
   firmware logs.
 
@@ -82,9 +102,11 @@ For details about our release process please read
 
 ### Changelog
 
-* Added system76_ectool to enable Embedded Controller [firmware updating](./documentation.md#ec-update).
-* Added ec_transition script which helps with full Dasharo/Embedded Controller
-  [firmware transition](./documentation.md#ec-transition) for NovaCustom NS5x/7x.
+* Added `system76_ectool` to enable Embedded Controller [firmware
+  updating](./documentation.md#ec-update).
+* Added `ec_transition` script, which helps with full Dasharo/Embedded
+  Controller [firmware transition](./documentation.md#ec-transition) for
+  NovaCustom NS5x/7x.
 * First public release: [meta-dts-ce](https://github.com/Dasharo/meta-dts-ce).
 
 ## v1.0.0
@@ -100,15 +122,16 @@ For details about our release process please read
   sha256sum -c [sha256 file]
   ```
 
-### Changelog
+### Changelogsystem76_ectool
 
 * Added auto-login functionality.
 * Added user menu.
-* [Dasharo HCL Report](../glossary.md#dasharo-hardware-compatibility-list-report)
-  which add the ability to automatically dump device information and send it to
-  3mdeb servers.
+* [Dasharo HCL
+  Report](../glossary.md#dasharo-hardware-compatibility-list-report), which adds
+  the ability to automatically dump device information and send it to 3mdeb
+  servers.
 * Possibility to manually [update the Dasharo
   firmware](./documentation.md#firmware-update).
-* [Bootable via iPXE](./documentation.md#bootable-over-network).
+* [Bootable via iPXE](./documentation.md#bootable-over-a-network).
 * [Bootable via USB](./documentation.md#bootable-usb-stick).
 * Tested on NovaCustom NV4x, Dell OptiPlex 7010/9010.


### PR DESCRIPTION
This PR was started to make some cleanups and formatting for next release (v1.1.1)

TODO:
- [x] no consistency in bullet endings
- [x] no tests results
- [x] inconsistencies in the use of capital letters in section names, e.g. EC Transition and EC update
- [x] grammarly check for typos
- [x] HOW TO boot DTS from iPXE without Dasharo - add iPXE commands
- [x] add info about results in HCL report

Signed-off-by: Tomasz Żyjewski <tomasz.zyjewski@3mdeb.com>