### PR TITLE
Remove Ubuntu 21.04 reference

### DIFF
--- a/docs/variants/msi_z690/building-manual.md
+++ b/docs/variants/msi_z690/building-manual.md
@@ -7,7 +7,7 @@ compatible with MSI PRO Z690-A WIFI DDR4.
 
 ## Requirements
 
-* `Ubuntu 20.04/21.04/22.04` as a host OS was tested
+* `Ubuntu 20.04/22.04` as a host OS was tested
 * Internet connection
 * Docker installed
     - follow [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)


### PR DESCRIPTION
Ubuntu 21.04 is end-of-life. 

Source: https://fridge.ubuntu.com/2022/01/21/ubuntu-21-04-hirsute-hippo-end-of-life-reached-on-january-20-2022/