### PR TITLE
docs/variants/msi_z690/recovery.md: add documented recovery methods to intro

### DIFF
--- a/docs/variants/msi_z690/recovery.md
+++ b/docs/variants/msi_z690/recovery.md
@@ -7,6 +7,9 @@ hardware configurations, the Dasharo firmware may not boot correctly (i.e.
 we will have "bricked" the platform). In such a case, the recovery procedure can
 reinstall the original firmware from the board manufacturer.
 
+There are two documented recovery methods: using a CH341A programming kit or an
+RTE external programmer.
+
 ### MSI Flash BIOS Button
 
 The [MSI Flash BIOS Button](https://www.youtube.com/watch?v=iTkXunUAriE)

--- a/docs/variants/msi_z690/recovery.md
+++ b/docs/variants/msi_z690/recovery.md
@@ -8,7 +8,7 @@ we will have "bricked" the platform). In such a case, the recovery procedure can
 reinstall the original firmware from the board manufacturer.
 
 There are two documented recovery methods: using a CH341A programming kit or an
-RTE external programmer.
+RTE.
 
 ### MSI Flash BIOS Button
 


### PR DESCRIPTION
Adding a concise overview of the two recovery methods helps orient the reader to the contents of the recovery documentation.

Signed-off-by: nedpfeiffer <116780681+nedpfeiffer@users.noreply.github.com>