### PR TITLE
docs/variants/msi_z690/recovery.md: paragraph order

### DIFF
--- a/docs/variants/msi_z690/recovery.md
+++ b/docs/variants/msi_z690/recovery.md
@@ -10,16 +10,6 @@ reinstall the original firmware from the board manufacturer.
 There are two documented recovery methods: using a [CH341A programming kit](https://3mdeb.com/shop/modules/ch341a-flash-bios-usb-programmer-kit-soic8-sop8/)
 or an [RTE](https://3mdeb.com/shop/open-source-hardware/rte/).
 
-### MSI Flash BIOS Button
-
-The [MSI Flash BIOS Button](https://www.youtube.com/watch?v=iTkXunUAriE)
-would give us easy-to-use recovery method. We have tried that one to switch
-from Dasharo firmware to the original one, but it did not work, unfortunately.
-The details of how this process exactly works are unknown due to the closed
-nature of it's implementation. We can research this topic more in the future,
-so maybe it can be utilized later for deployment and/or recovery of the
-platform.
-
 ### External flashing with programmer
 
 #### RTE
@@ -175,6 +165,16 @@ Reading old flash chip contents... done.
 Erasing and writing flash chip... Erase/write done.
 Verifying flash... VERIFIED.
 ```
+
+### MSI Flash BIOS Button
+
+The [MSI Flash BIOS Button](https://www.youtube.com/watch?v=iTkXunUAriE)
+would give us easy-to-use recovery method. We have tried that one to switch
+from Dasharo firmware to the original one, but it did not work, unfortunately.
+The details of how this process exactly works are unknown due to the closed
+nature of it's implementation. We can research this topic more in the future,
+so maybe it can be utilized later for deployment and/or recovery of the
+platform.
 
 ## SMBIOS unique data recovery
 


### PR DESCRIPTION
Per the Dasharo [documentation guidelines](https://docs.dasharo.com/dev-proc/documentation-guidelines/) the most important information should be at the top of the documentation. Since flashing with the MSI Flash BIOS Button does not currently work, I moved it to the bottom. Let me know what you think.