### PR TITLE
Update build.sh arguments for Z690-A DDR4 build

### DIFF
--- a/docs/variants/msi_z690/building-manual.md
+++ b/docs/variants/msi_z690/building-manual.md
@@ -46,7 +46,7 @@ Navigate to the source code directory and start the build process:
 
 ```bash
 cd coreboot
-./build.sh dd4
+./build.sh ddr4
 ```
 
 The resulting Dasharo firmware image will be placed at `build/coreboot.rom`.


### PR DESCRIPTION
While following the build steps, I noticed a command was not working as expected. I get this error:

```
user@nixos ~/dev/coreboot (tags/msi_ms7d25_v1.1.1) $ ./build.sh build
Invalid command: "build"
```

Running the script with no arguments shows two available options, `ddr4` and `ddr5`. Since this page refers already to DDR4, I fixed up the build script argument to match.