### PR TITLE
MSI recovery.md WSON8 probe specify 8x6mm

### DIFF
--- a/docs/unified/msi/recovery.md
+++ b/docs/unified/msi/recovery.md
@@ -70,7 +70,7 @@ The full set is now available at our [online shop](https://shop.3mdeb.com/shop/m
 
     ![](/images/ch341a_rec/ch341a_kit.jpg)
 
-2. WSON8 probe. Can be bought from China on Aliexpress or eBay.
+2. WSON8 probe, 8x6mm. Can be bought from China on Aliexpress or eBay.
 
     ![](/images/ch341a_rec/wson8_probe.jpg)
 


### PR DESCRIPTION
WSON8 exists in 8x6 and 6x5mm packages.  
Part number on the image of the BIOS flash IC ![](https://docs.dasharo.com/images/ch341a_rec/msi_flash.jpg) is 25q256jweq, as per [datasheet](https://eu.mouser.com/datasheet/2/949/w25q256jw_spi_revd_09042018-1489579.pdf) page 93 that is an 8-pad WSON 8x6mm.

Or are there MSI boards that use the smaller 6x5mm package?