### PR TITLE
fix pre-commit hooks intallation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
-# See https://pre-commit.com/hooks.html for more hooks
 ---
+default_stages: [pre-commit]
+
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ There should be no TBD or TODO visible on the website.
 - Install hooks into repo:
 
 ```shell
-pre-commit install --hook-type commit-msg
+pre-commit install
 ```
 
 - Enjoy automatic checks on each `git commit` action!


### PR DESCRIPTION
With the documentation we had, only commit-msg hooks were installed. What is more, we had the stages assigned wrong for specific checks (by default, each hook was assigned to each stage, so also to commit-msg).

As a result, this would result in pre-commit (in fact: commit-msg) checks to appear as if they would PASS, even if they were supposed to FAIL (and were failing in CI). In fact, most of the pre-commit hooks on files were never executed.

Refer to the pre-commit config and default values: https://pre-commit.com/#pre-commit-configyaml---top-level