### PR TITLE
variants/novacustom_nv4x_adl/releases.md: remove link to dev_signed bin

### DIFF
--- a/docs/variants/novacustom_nv4x_adl/releases.md
+++ b/docs/variants/novacustom_nv4x_adl/releases.md
@@ -87,10 +87,6 @@ Test results for this release can be found
 [sha256][novacustom_nv4x_adl_v1.7.0.rom_hash]{.md-button}
 [sha256.sig][novacustom_nv4x_adl_v1.7.0.rom_sig]{.md-button}
 
-[novacustom_nv4x_adl_v1.7.0_dev_signed.rom][novacustom_nv4x_adl_v1.7.0_dev_signed.rom_file]{.md-button}
-[sha256][novacustom_nv4x_adl_v1.7.0_dev_signed.rom_hash]{.md-button}
-[sha256.sig][novacustom_nv4x_adl_v1.7.0_dev_signed.rom_sig]{.md-button}
-
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)
 using [this key](https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/customer-keys/novacustom/novacustom-open-source-firmware-release-1.x-key.asc)
@@ -106,9 +102,6 @@ using [this key](https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/cu
 [novacustom_nv4x_adl_v1.7.0.rom_file]: https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_nv4x_adl/v1.7.0/novacustom_nv4x_adl_v1.7.0.rom
 [novacustom_nv4x_adl_v1.7.0.rom_hash]: https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_nv4x_adl/v1.7.0/novacustom_nv4x_adl_v1.7.0.rom.sha256
 [novacustom_nv4x_adl_v1.7.0.rom_sig]: https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_nv4x_adl/v1.7.0/novacustom_nv4x_adl_v1.7.0.rom.sha256.sig
-[novacustom_nv4x_adl_v1.7.0_dev_signed.rom_file]: https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_nv4x_adl/v1.7.0/novacustom_nv4x_adl_v1.7.0_dev_signed.rom
-[novacustom_nv4x_adl_v1.7.0_dev_signed.rom_hash]: https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_nv4x_adl/v1.7.0/novacustom_nv4x_adl_v1.7.0_dev_signed.rom.sha256
-[novacustom_nv4x_adl_v1.7.0_dev_signed.rom_sig]: https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_nv4x_adl/v1.7.0/novacustom_nv4x_adl_v1.7.0_dev_signed.rom.sha256.sig
 
 ## v1.6.0 - 2023-04-19
 


### PR DESCRIPTION
dev_signed binaries are used for testing and development, but are not relevant for regular users and introduce unnecessary confusion. A user has already asked which one they should use.

Remove the link for clarity.