### PR TITLE
msi/hcl: fix 1080ti bandwith value

### DIFF
--- a/docs/unified/msi/hcl.md
+++ b/docs/unified/msi/hcl.md
@@ -206,7 +206,7 @@ hardware.
     | MSI Radeon RX 6950 XT     | 16 GB    | GDDR6  | 576GB/s   | Gen4      | 1                         | |
     | EVGA NVidia RTX 2080      | 8 GB     | GDDR6  | 448GB/s   | Gen3      | 1                         | |
     | PNY NVidia RTX A5000      | 24 GB    | GDDR6  | 768GB/s   | Gen4      | 1                         | |
-    | Nvidia GeForce GTX 1080TI | 11264 MB | GDDR5X | x16       | Gen3      | 1                         | [Qubes HCL reports][2] |
+    | Nvidia GeForce GTX 1080TI | 11264 MB | GDDR5X | 484GB/s   | Gen3      | 1                         | [Qubes HCL reports][2] |
     | MSI Radeon RX 6500 XT MECH 2X 4G OC | 4 GB     | GDDR6  | 180GB/s   | Gen4      | 1                         | Works only on Dasharo v1.1.0 or newer |
     | MSI GeForce RTX 3060 GAMING Z TRIO LHR | 12 GB     | GDDR6  | 358GB/s   | Gen4      | 1                         | |
 


### PR DESCRIPTION
"Bandwidth" here refers to video memory bandwidth, not the PCIe link width.