### PR TITLE
Formatting fixes

### DIFF
--- a/docs/unified-test-documentation/dasharo-compatibility/319-nvidia-graphics.md
+++ b/docs/unified-test-documentation/dasharo-compatibility/319-nvidia-graphics.md
@@ -83,7 +83,7 @@ Get-WmiObject -Class Win32_VideoController | Select Description, Name, Status
 
 **Expected result**
 
-1. The output should contain the information about installed Nvidia Graphics
+1. The output should contain the information about installed NVIDIA Graphics
     card.
 
     Example output:

--- a/docs/unified/clevo/post-install.md
+++ b/docs/unified/clevo/post-install.md
@@ -36,7 +36,7 @@ Select your operating system to view applicable instructions:
 
     and reboot to use the new kernel.
 
-    ### Nvidia drivers
+    ### NVIDIA drivers
 
     If your device comes with NVIDIA graphics, proprietary NVIDIA drivers are
     recommended for optimal performance and battery life.

--- a/docs/unified/msi/hcl.md
+++ b/docs/unified/msi/hcl.md
@@ -236,11 +236,11 @@ hardware.
     | GPU name         | Memory size | Memory type  | Bandwidth | PCI-E Gen | Multi-Graphics Technology | Results                |
     |:----------------:|:-----------:|:------------:|:---------:|:---------:|:-------------------------:|:----------------------:|
     | AMD Radeon RX 5700 XT     | 8 GB     | GDDR6  | 448GB/s   | Gen4      | 1                         | |
-    | Nvidia GeForce GTX 1060   | 3072 MB  | GDDR5  | 192GB/s   | Gen3      | 1                         | [Qubes HCL reports][1] |
+    | NVIDIA GeForce GTX 1060   | 3072 MB  | GDDR5  | 192GB/s   | Gen3      | 1                         | [Qubes HCL reports][1] |
     | MSI Radeon RX 6950 XT     | 16 GB    | GDDR6  | 576GB/s   | Gen4      | 1                         | |
-    | EVGA NVidia RTX 2080      | 8 GB     | GDDR6  | 448GB/s   | Gen3      | 1                         | |
-    | PNY NVidia RTX A5000      | 24 GB    | GDDR6  | 768GB/s   | Gen4      | 1                         | |
-    | Nvidia GeForce GTX 1080TI | 11264 MB | GDDR5X | 484GB/s   | Gen3      | 1                         | [Qubes HCL reports][2] |
+    | EVGA NVIDIA RTX 2080      | 8 GB     | GDDR6  | 448GB/s   | Gen3      | 1                         | |
+    | PNY NVIDIA RTX A5000      | 24 GB    | GDDR6  | 768GB/s   | Gen4      | 1                         | |
+    | NVIDIA GeForce GTX 1080TI | 11264 MB | GDDR5X | 484GB/s   | Gen3      | 1                         | [Qubes HCL reports][2] |
     | MSI Radeon RX 6500 XT MECH 2X 4G OC | 4 GB     | GDDR6  | 180GB/s   | Gen4      | 1                         | Works only on Dasharo v1.1.0 or newer |
     | MSI GeForce RTX 3060 GAMING Z TRIO LHR | 12 GB     | GDDR6  | 358GB/s   | Gen4      | 1                         | |
 

--- a/docs/variants/msi_z690/releases.md
+++ b/docs/variants/msi_z690/releases.md
@@ -243,7 +243,7 @@ Test results for this release can be found
 
 ### Fixed
 
-- [Nvidia RTX 3060 does not spawn HD Audio device in Device Manager](https://github.com/Dasharo/dasharo-issues/issues/364)
+- [NVIDIA RTX 3060 does not spawn HD Audio device in Device Manager](https://github.com/Dasharo/dasharo-issues/issues/364)
 - [MSI FLASHBIOS feature is not working](https://github.com/Dasharo/dasharo-issues/issues/131)
 - [Reset to defaults with F9 causes the wrong settings to be restored](https://github.com/Dasharo/dasharo-issues/issues/355)
 - [Popup with information about recovery mode is displayed after flashing with a valid binary](https://github.com/Dasharo/dasharo-issues/issues/269)

--- a/docs/variants/msi_z790/releases.md
+++ b/docs/variants/msi_z790/releases.md
@@ -247,7 +247,7 @@ Test results for this release can be found
 
 ### Fixed
 
-- [Nvidia RTX 3060 does not spawn HD Audio device in Device Manager](https://github.com/Dasharo/dasharo-issues/issues/364)
+- [NVIDIA RTX 3060 does not spawn HD Audio device in Device Manager](https://github.com/Dasharo/dasharo-issues/issues/364)
 - [MSI FLASHBIOS feature is not working](https://github.com/Dasharo/dasharo-issues/issues/131)
 - [Reset to defaults with F9 causes the wrong settings to be restored](https://github.com/Dasharo/dasharo-issues/issues/355)
 - [Popup with information about recovery mode is displayed after flashing with a valid binary](https://github.com/Dasharo/dasharo-issues/issues/269)

--- a/docs/variants/novacustom_nv4x_tgl/releases.md
+++ b/docs/variants/novacustom_nv4x_tgl/releases.md
@@ -516,7 +516,7 @@ using [this key](https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/cu
 ### Fixed
 
 - [Performance drop when the power adaptor is disconnected](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/5)
-- [High Nvidia GPU energy draw at idle in Windows](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/6)
+- [High NVIDIA GPU energy draw at idle in Windows](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/6)
 
 ### Known issues
 
@@ -561,7 +561,7 @@ using [this key](https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/cu
 
 - [Unable to download the system by using iPXE](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/8)
 - [Laptop cannot output video via the Tunderbolt 4 USB Type-C port](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/7)
-- [High Nvidia GPU energy draw at idle in Windows](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/6)
+- [High NVIDIA GPU energy draw at idle in Windows](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/6)
 - [Performance drop when the power adaptor is disconnected](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/5)
 - [The touchpad ON/OFF switch Fn key is not functional](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/1)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -577,7 +577,7 @@ nav:
               - '[MSS] M.2 slot support with automatic switching between SATA and NVMea': unified-test-documentation/dasharo-compatibility/31I-nvme-switching.md
               - '[MWL] miniPCIe verification': unified-test-documentation/dasharo-compatibility/31K-minipcie-verification.md
               - '[NBT] Network boot utilities': unified-test-documentation/dasharo-compatibility/315b-netboot-utilities.md
-              - '[NVI] Nvidia Graphics support': unified-test-documentation/dasharo-compatibility/319-nvidia-graphics.md
+              - '[NVI] NVIDIA Graphics support': unified-test-documentation/dasharo-compatibility/319-nvidia-graphics.md
               - '[NVM] NVME support': unified-test-documentation/dasharo-compatibility/312-nvme-support.md
               - '[OPN] OPNsense support': unified-test-documentation/dasharo-compatibility/342-OPNsense-support.md
               - '[PBT] Petitboot payload support': unified-test-documentation/dasharo-compatibility/31V-petitboot-payload-support.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -547,7 +547,7 @@ nav:
               - '[CAM] USB Camera Verification': unified-test-documentation/dasharo-compatibility/317-usb-camera.md
               - '[CBK] Custom Boot Menu Key': unified-test-documentation/dasharo-compatibility/303-custom-boot-menu-key.md
               - '[CBO] Custom Boot Order': unified-test-documentation/dasharo-compatibility/325-custom-boot-order.md
-              - '[CBP] Coreboot Base Port': unified-test-documentation/dasharo-compatibility/100-coreboot-base-port.md
+              - '[CBP] coreboot Base Port': unified-test-documentation/dasharo-compatibility/100-coreboot-base-port.md
               - '[CLG] Custom Logo': unified-test-documentation/dasharo-compatibility/304-custom-logo.md
               - '[CNB] Custom Network Boot entries': unified-test-documentation/dasharo-compatibility/30A-custom-network-boot-entries.md
               - '[CPU] CPU status': unified-test-documentation/dasharo-compatibility/31T-cpu-status.md


### PR DESCRIPTION
Sort tests alphabetically for easier browsing (previously they were *roughly* sorted by ID), and replace `Coreboot` with `coreboot`.