### PR TITLE
docs/dasharo-tools-suite/releases.md: hide earlier releases

### DIFF
--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -3,7 +3,7 @@
 Following Release Notes describe the status of Open Source Software development
 for Dasharo Tools Suite.
 
-## Latest release
+## **Latest release**
 
 **Versions newer than `v1.2.11` are not published here.**{ .md-banner--warning }
 Instead, they can be found on `meta-dts` GitHub repository, inside `Releases`
@@ -13,6 +13,9 @@ tab. The button below will take you there there.
 
 [Latest]: https://github.com/Dasharo/meta-dts/releases
 
+Using the latest release is recommended.
+
+<!--
 ## v1.2.11 - 2023-11-03
 
 ### Images
@@ -78,14 +81,12 @@ Beta/preview release
 ### Images
 
 [USB bootable DTS v1.2.6 image][USB_DTS_v1.2.6]{ .md-button }
-<!--
 [sha256][USB_DTS_sha_v1.2.6]{ .md-button }
 [sha256.sig][USB_DTS_sig_v1.2.6]{ .md-button }
 
 [DTS v1.2.6 ISO image][ISO_DTS_v1.2.6]{ .md-button }
 [sha256 ISO][ISO_DTS_sha_v1.2.6]{ .md-button }
 [sha256.sig ISO][ISO_DTS_sig_v1.2.6]{ .md-button }
--->
 
 [USB_DTS_v1.2.6]: https://3mdeb.com/open-source-firmware/DTS/dts-base-image-v1.2.6.wic.gz
 [ISO_DTS_v1.2.6]: https://3mdeb.com/open-source-firmware/DTS/dts-base-image-v1.2.6.iso
@@ -291,3 +292,4 @@ stored in `meta-dts` repository.
 * [Bootable via iPXE](./documentation.md#bootable-over-a-network).
 * [Bootable via USB](./documentation.md#bootable-usb-stick).
 * Tested on NovaCustom NV4x, Dell OptiPlex 7010/9010.
+-->

--- a/docs/dasharo-tools-suite/releases.md
+++ b/docs/dasharo-tools-suite/releases.md
@@ -13,9 +13,15 @@ tab. The button below will take you there there.
 
 [Latest]: https://github.com/Dasharo/meta-dts/releases
 
-Using the latest release is recommended.
+**Using the latest release is strongly recommended.**
 
-<!--
+---
+
+# Older releases
+
+In this section you can find old releases, that are not available on the
+Github [Releases](https://github.com/Dasharo/meta-dts/releases) page.
+
 ## v1.2.11 - 2023-11-03
 
 ### Images
@@ -81,12 +87,14 @@ Beta/preview release
 ### Images
 
 [USB bootable DTS v1.2.6 image][USB_DTS_v1.2.6]{ .md-button }
+<!--
 [sha256][USB_DTS_sha_v1.2.6]{ .md-button }
 [sha256.sig][USB_DTS_sig_v1.2.6]{ .md-button }
 
 [DTS v1.2.6 ISO image][ISO_DTS_v1.2.6]{ .md-button }
 [sha256 ISO][ISO_DTS_sha_v1.2.6]{ .md-button }
 [sha256.sig ISO][ISO_DTS_sig_v1.2.6]{ .md-button }
+-->
 
 [USB_DTS_v1.2.6]: https://3mdeb.com/open-source-firmware/DTS/dts-base-image-v1.2.6.wic.gz
 [ISO_DTS_v1.2.6]: https://3mdeb.com/open-source-firmware/DTS/dts-base-image-v1.2.6.iso
@@ -292,4 +300,3 @@ stored in `meta-dts` repository.
 * [Bootable via iPXE](./documentation.md#bootable-over-a-network).
 * [Bootable via USB](./documentation.md#bootable-usb-stick).
 * Tested on NovaCustom NV4x, Dell OptiPlex 7010/9010.
--->


### PR DESCRIPTION
This PR does two things:
* comments out all the earlier releases, so that they aren't visible on the page
* makes the `Latest release` section bold, so that users have no choice but to go to the releases page and download the latest version