### PR TITLE
docs/dasharo-tools-suite/documentation.md: add info about ipxe boot

### DIFF
--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -317,7 +317,7 @@ This section describes the functionality of the Dasharo Tools Suite. These are:
 * [EC transition](#ec-transition),
 * [EC update](#ec-update),
 * [additional features](#additional-features),
-    - [run commands from iPXE shell](#run-commands-from-ipxe-shell),
+    - [run commands from iPXE shell automatically](#run-commands-from-ipxe-shell-automatically),
     - [run DTS using VentoyOS](#run-dts-using-ventoyos).
 
 ### Dasharo zero-touch initial deployment


### PR DESCRIPTION
This script adds info on how to boot dts through iPXE while also executing a custom user script at the end.

This can be done with the `local-ipxe-server.sh` script added in [this pr](https://github.com/Dasharo/meta-dts/pull/96) in `meta-dts`

This is related to [this issue](https://github.com/Dasharo/dasharo-issues/issues/387)