### PR TITLE
docs/variants/protectli_vp46xx/overview.md: mention both CPU versions

### DIFF
--- a/docs/variants/protectli_vp46xx/overview.md
+++ b/docs/variants/protectli_vp46xx/overview.md
@@ -13,7 +13,8 @@ and WWAN slots.
 
 * VP4630 - Intel Core i3-10110U
 * VP4650 - Intel Core i5-10210U
-* VP4670 - Intel Core i7-10810U
+* VP4670 - Intel Core i7-10810U (both v1 and v2 versions, see the
+  [Intel FSP repo for details](https://github.com/intel/FSP/tree/master/CometLakeFspBinPkg#differentiating-cometlake1-and-cometlake2)))
 
 For more information please refer to the references below.
 


### PR DESCRIPTION
This commit clarifies that we support both v1 and v2 of VP4650 and
VP4670.

Signed-off-by: Piotr Kubaj <piotr.kubaj@3mdeb.com>
