### PR TITLE
docs/variants: update Protectli documentation

### DIFF
--- a/docs/variants/protectli_vp2410/overview.md
+++ b/docs/variants/protectli_vp2410/overview.md
@@ -21,6 +21,9 @@ VP2410 specification:
 * Included 12v Power Supply, VESA mount kit, Serial Console Cable,
 SATA data and power cables for internal SSD, Quick Start Guide
 
+> On VP2410 Intel ME (Management Engine) is not supported by coreboot causing
+> Intel ME to enter recovery mode giving similar results to disabled ME.
+
 For more information please refer to the references below.
 
 ## References

--- a/docs/variants/protectli_vp2420/overview.md
+++ b/docs/variants/protectli_vp2420/overview.md
@@ -23,6 +23,10 @@ VP2410 specification:
 * Included 12v Power Supply, VESA mount kit, Serial Console Cable,
 SATA data and power cables for internal SSD, Quick Start Guide
 
+> Starting with Dasharo [v1.2.0](releases.md#v120-2024-05-16), Intel ME
+> (Management Engine) is [soft-disabled](../../osf-trivia-list/me.md#soft-disabling-me)
+> by default.
+
 For more information please refer to the references below.
 
 ## References

--- a/docs/variants/protectli_vp46xx/overview.md
+++ b/docs/variants/protectli_vp46xx/overview.md
@@ -16,6 +16,10 @@ and WWAN slots.
 * VP4670 - Intel Core i7-10810U (both v1 and v2 versions, see the
   [Intel FSP repo for details](https://github.com/intel/FSP/tree/master/CometLakeFspBinPkg#differentiating-cometlake1-and-cometlake2)))
 
+> Starting with Dasharo [v1.0.19](releases.md#v1019-2022-12-08) Intel ME
+> (Management Engine) is
+> [soft-disabled](../../osf-trivia-list/me.md#soft-disabling-me).
+
 For more information please refer to the references below.
 
 ## References

--- a/docs/variants/protectli_vp46xx/overview.md
+++ b/docs/variants/protectli_vp46xx/overview.md
@@ -14,7 +14,7 @@ and WWAN slots.
 * VP4630 - Intel Core i3-10110U
 * VP4650 - Intel Core i5-10210U
 * VP4670 - Intel Core i7-10810U (both v1 and v2 versions, see the
-  [Intel FSP repo for details](https://github.com/intel/FSP/tree/master/CometLakeFspBinPkg#differentiating-cometlake1-and-cometlake2)))
+  [Intel FSP repo for details](https://github.com/intel/FSP/tree/master/CometLakeFspBinPkg#differentiating-cometlake1-and-cometlake2))
 
 > Starting with Dasharo [v1.0.19](releases.md#v1019-2022-12-08) Intel ME
 > (Management Engine) is

--- a/docs/variants/protectli_vp46xx/releases.md
+++ b/docs/variants/protectli_vp46xx/releases.md
@@ -144,7 +144,7 @@ using [this key](https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/cu
 
 ### Changed
 
-- ME is now disabled by default (ME soft-disable)
+- ME is now disabled by default ([ME soft-disable]((../../osf-trivia-list/me.md#soft-disabling-me)))
 - vboot is now run as separate verstage (previously was run inside bootblock)
 - increased pre-RAM console buffer to fit more early cbmem logs
 

--- a/docs/variants/protectli_vp46xx/releases.md
+++ b/docs/variants/protectli_vp46xx/releases.md
@@ -144,7 +144,7 @@ using [this key](https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/cu
 
 ### Changed
 
-- ME is now disabled by default ([ME soft-disable]((../../osf-trivia-list/me.md#soft-disabling-me)))
+- ME is now disabled by default ([ME soft-disable](../../osf-trivia-list/me.md#soft-disabling-me))
 - vboot is now run as separate verstage (previously was run inside bootblock)
 - increased pre-RAM console buffer to fit more early cbmem logs
 

--- a/docs/variants/protectli_vp66xx/overview.md
+++ b/docs/variants/protectli_vp66xx/overview.md
@@ -12,6 +12,9 @@ TPM, 2 CPU fans.
 * VP6650 - Intel® Core™ i5 -1235U
 * VP6670 - Intel® Core™ i7 -1255U
 
+> On VP66xx Intel ME (Management Engine) is disabled by using the
+> [HAP bit](../../osf-trivia-list/me.md#hap-altmedisable-bit-aka-disabling-me).
+
 ## Documentation sections
 
 * [Releases](releases.md) - groups information about all releases.


### PR DESCRIPTION
Update documentation about Intel ME status. Add note to each platform which has Intel ME disabled.