### PR TITLE
unified-test-documentation/nvidia-graphics: VGA Controller is pass

### DIFF
--- a/docs/unified-test-documentation/dasharo-compatibility/319-nvidia-graphics.md
+++ b/docs/unified-test-documentation/dasharo-compatibility/319-nvidia-graphics.md
@@ -41,11 +41,17 @@ initialized and can be detected by the operating system.
 
 **Expected result**
 
-1. The command should return one line containing the name of the graphics
+1. The command should return the name of the graphics
    card, e.g:
 
     ```bash
     2d:00.0 3D controller: NVIDIA Corporation TU117M (rev a1)
+    ```
+
+    or
+
+    ```bash
+    01:00.1 VGA compatible controller: NVIDIA Corporation AD106M [GeForce RTX 4070 Max-Q / Mobile] (rev a1)
     ```
 
 ## NVI001.002 NVIDIA Graphics detect (Windows)


### PR DESCRIPTION
Related to https://github.com/Dasharo/open-source-firmware-validation/pull/467
- The output does not necessarily need to be one line, if there is an nvidia audio device, for example, the output will be longer
- The text implies that only the name of a device is sufficient but one may think it needs to contain the "3D controller" so another example may solve any misunderstandings