### PR TITLE
Rename Dasharo Entry Subscription to Dasharo Pro Package

### DIFF
--- a/docs/dasharo-tools-suite/documentation.md
+++ b/docs/dasharo-tools-suite/documentation.md
@@ -278,10 +278,10 @@ boot DTS, choose option number `2`. After creating
 firmware dump as backup, type `d` or `c` to confirm the installation of Dasharo
 firmware. Option `c` stands for community release which is available for anyone
 using Dasharo Tools Suite, option `d` stands for
-[DES](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-entry-subscription-subscriber)
-release and it is only available to Dasharo Entry Subscription subscribers.
+[DPP](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-entry-subscription-subscriber)
+release and it is only available to Dasharo Pro Package subscribers.
 If you have DPP subscription then do steps in
-[How can I use my Dasharo Entry Subscription credentials](
+[How can I use my Dasharo Pro Package credentials](
 ../osf-trivia-list/dts.md#how-can-i-use-my-dasharo-entry-subscription-credentials)
 section first.
 
@@ -395,10 +395,9 @@ Please consider the following options depending on your situation:
 
 DTS can be used to update Dasharo firmware. To achieve this, boot it on platform
 with flashed Dasharo and choose option number `2`. You may see additional
-information about available updates if you are not [Dasharo Entry
-Subscription](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-entry-subscription-subscriber)
+information about available updates if you are not [Dasharo Pro Package](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-entry-subscription-subscriber)
 subscriber. If you have DPP subscription then do steps in
-[How can I use my Dasharo Entry Subscription credentials](
+[How can I use my Dasharo Pro Package credentials](
 ../osf-trivia-list/dts.md#how-can-i-use-my-dasharo-entry-subscription-credentials)
 section first.
 
@@ -446,7 +445,7 @@ v1.1.1 on MSI PRO Z690-A DDR4.
 **     1) Dasharo HCL report
 **     2) Update Dasharo Firmware
 **     3) Restore firmware from Dasharo HCL report
-**     4) Load your DES keys
+**     4) Load your DPP keys
 *********************************************************
 Select a menu option or
 R to reboot  P to poweroff  S to enter shell

--- a/docs/dev-proc/versioning.md
+++ b/docs/dev-proc/versioning.md
@@ -14,24 +14,24 @@ in menu on the left side (Supported Hardware->Hardware Model->Releases).
 
 Dasharo Releases can be divided into two categories:
 
-* Dasharo Entry Subscription Releases (previous Dasharo Supporters Release for
+* Dasharo Pro Package Releases (previous Dasharo Supporters Release for
   Dasharo Support Entrance Subscribers)
 * Dasharo Community Releases
 
-## Dasharo Entry Subscription Releases
+## Dasharo Pro Package Releases
 
-Dasharo Entry Subscription subscribers receive firmware updates more
+Dasharo Pro Package subscribers receive firmware updates more
 frequently than the community. The number of updates per year depends on the
-number of Dasharo Entry Subscriptions sold and the availability of other
+number of Dasharo Pro Packages sold and the availability of other
 funding (e.g., NLNet, corporate sponsors, community donations) but is less
-than 2 updates per year. Dasharo Entry Subscription Releases are characterized
+than 2 updates per year. Dasharo Pro Package Releases are characterized
 by a changing patch version (`z`). Fixes and features introduced in Dasharo
-Entry Subscription Releases will also be available later as Dasharo Community
+Pro Package Releases will also be available later as Dasharo Community
 Releases with public pre-built binaries in the respective release pages. In
 short, being a Dasharo Subscriber gives early access to the newest features
 and fixes.
 
-[How to become Dasharo Entry Subscription subscriber?](../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber)
+[How to become Dasharo Pro Package subscriber?](../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber)
 
 ## Dasharo Community Releases
 

--- a/docs/osf-trivia-list/dasharo-entry-subscription.md
+++ b/docs/osf-trivia-list/dasharo-entry-subscription.md
@@ -1,8 +1,8 @@
-# Frequenty Asked Questions about Dasharo Entry Subscription
+# Frequently Asked Questions about Dasharo Pro Package
 
-## How can I download the Dasharo Entry Subscription binaries?
+## How can I download the Dasharo Pro Package binaries?
 
-If you've purchased the Dasharo Entry Subscription, you should have received an
+If you've purchased the Dasharo Pro Package, you should have received an
 email containing all the necessary details to access your binaries. Here's how
 you can download them:
 
@@ -45,8 +45,8 @@ you can download them:
 - If you have not received your email or cannot find it, check your spam folder
   or contact Dasharo support for assistance.
 
-Following these steps, you can access and download your Dasharo Entry
-Subscription binaries without issues. If you encounter any problems, don't
+Following these steps, you can access and download your Dasharo Pro Package
+binaries without issues. If you encounter any problems, don't
 hesitate to contact the Dasharo support team for further assistance.
 
 ## Does the Pro Package keys have any bearing on the hardware or BIOS?

--- a/docs/osf-trivia-list/dasharo.md
+++ b/docs/osf-trivia-list/dasharo.md
@@ -26,7 +26,7 @@ and maintain a high quality, and modular firmware, for the stability and
 security of your platform.
 
 For individuals Dasharo provides optional features in subscription model called
-[Dasharo Entry Subscription](../dev-proc/versioning.md#dasharo-entry-subscription-releases).
+[Dasharo Pro Package](../dev-proc/versioning.md#dasharo-entry-subscription-releases).
 
 ## Why 3mdeb created Dasharo?
 

--- a/docs/osf-trivia-list/dts.md
+++ b/docs/osf-trivia-list/dts.md
@@ -8,20 +8,20 @@ debugging and development support.
 
 Also refer to [DTS Overview](../dasharo-tools-suite/overview.md).
 
-## How to get Dasharo Entry Subscription Releases using Dasharo Tools Suite?
+## How to get Dasharo Pro Package Releases using Dasharo Tools Suite?
 
-Dasharo Entry Subscription Releases can be used to perform firmware updates
-with DTS by providing Dasharo Entry Subscription credentials obtained after
-buying a [Dasharo Entry Subscription](../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+Dasharo Pro Package Releases can be used to perform firmware updates
+with DTS by providing Dasharo Pro Package credentials obtained after
+buying a [Dasharo Pro Package](../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 
 Commercial use of DTS should be discussed directly with
 [3mdeb](mailto:leads@3mdeb.com) or [Dasharo Team](mailto:contact@dasharo.com).
 
-### How can I use my Dasharo Entry Subscription credentials
+### How can I use my Dasharo Pro Package credentials
 
 <!-- Need to be replaced in case the menu changed. -->
 
-After purchasing the Dasharo Entry Subscription, you should receive an email
+After purchasing the Dasharo Pro Package, you should receive an email
 with keys to use with [Dasharo Tools Suite](../dasharo-tools-suite/overview.md).
 This section describes how to do it.
 
@@ -29,7 +29,7 @@ This section describes how to do it.
   [here](../dasharo-tools-suite/documentation.md#bootable-usb-stick).
 
 * After booting, you will see a text menu, choose option number 4,
-  `Load your DES keys`, by pressing `4` and `Enter`.
+  `Load your DPP keys`, by pressing `4` and `Enter`.
 
 * Next, rewrite the credentials received in the following order:
     - `logs key`,
@@ -37,10 +37,10 @@ This section describes how to do it.
     - `password`.
 
 * Credentials will be verified by DTS attempting to connect to our server. If
-  successful, the message `Verification of the Dasharo DES was successful. They
+  successful, the message `Verification of the Dasharo DPP was successful. They
   are valid and will be used.` will be displayed.
 
-Below is a short video that present loading DES keys.
+Below is a short video that present loading DPP keys.
 
 ![IMG](img/des-creds.gif)
 

--- a/docs/unified-test-documentation/dasharo-compatibility/326-dasharo-tools-suite.md
+++ b/docs/unified-test-documentation/dasharo-compatibility/326-dasharo-tools-suite.md
@@ -417,7 +417,7 @@ the previous to the currently tested version.
 1. Press the `Enter` key to begin downloading DTS.
 1. If required, enter the appropriate credentials in the DTS menu.
 
-> Credential for DES releases are not publicly available. If you need DES
+> Credential for DPP releases are not publicly available. If you need DPP
 > credentials for testing DTS, consult your TL.
 
 1. Select the `Update Dasharo Firmware` option to check for update.

--- a/docs/unified/msi/faq.md
+++ b/docs/unified/msi/faq.md
@@ -136,7 +136,7 @@ The list of all supported memory modules is available in the
 
 The Dasharo Subscription includes:
 
-* The latest Dasharo Entry Subscription release installed by the Dasharo Team
+* The latest Dasharo Pro Package release installed by the Dasharo Team
 * Dasharo Updates – The number of updates depends on the number of Dasharo
   Subscriptions sold and the availability of other funding (e.g., NLNet,
   corporate sponsors, [community

--- a/docs/unified/msi/firmware-transition.md
+++ b/docs/unified/msi/firmware-transition.md
@@ -17,7 +17,7 @@ Heads subscription credentials to transition to Heads.
 Use [FlashBIOS](../../unified/msi/recovery.md#using-msi-flashbios-button)
 method (recommended) or flash with flashrom in OS. To use FlashBIOS we
 recommend to switch back to MSI UEFI firmware (if you don't have the desktop
-Dasharo Entry Subscription or not running Dasharo v1.1.3) and then use
+Dasharo Pro Package or not running Dasharo v1.1.3) and then use
 FlashBIOS with heads binary.
 
 To transition to heads firmware with flashrom, whole binary has to be flashed:

--- a/docs/unified/novacustom/firmware-transition.md
+++ b/docs/unified/novacustom/firmware-transition.md
@@ -27,7 +27,7 @@ firmware installation:
     [Dasharo menu documentation](https://docs.dasharo.com/dasharo-menu-docs/).
 
 - [Boot into Dasharo Tools Suite](https://docs.dasharo.com/dasharo-tools-suite/documentation/#running)
-- Enter your DES subscription credentials
+- Enter your DPP subscription credentials
 - Select `Update Dasharo firmware` to check for updates
 - When asked to switch to Heads firmware, press `Y`
 - Proceed with [DTS firmware update](https://docs.dasharo.com/dasharo-tools-suite/documentation/#firmware-update)

--- a/docs/unified/novacustom/overview.md
+++ b/docs/unified/novacustom/overview.md
@@ -103,7 +103,7 @@ Select your Dasharo firmware flavor:
     - [NS5x/7x 11th Gen](/variants/novacustom_ns5x_tgl/releases/)
 
 === "Dasharo (coreboot + Heads)"
-    Heads-based firmware is offered as a Dasharo Entry Subscription option.
+    Heads-based firmware is offered as a Dasharo Pro Package option.
 
     !!! note
 

--- a/docs/variants/msi_z690/releases.md
+++ b/docs/variants/msi_z690/releases.md
@@ -39,7 +39,7 @@ Test results for this release can be found
 
 ### Changed
 
-- [This is a Dasharo Entry Subscription release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
+- [This is a Dasharo Pro Package release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
 - [Updated microcode to the newer version; refer to SBOM section below](https://github.com/coreboot/intel-microcode/commit/6788bb07eb5f9e9b83c31ea1364150fe898f450a)
 - [Updated ME to the newer version; refer to SBOM section below](https://github.com/Dasharo/dasharo-blobs/tree/main/msi/ms7d25)
 - [Switched to the Raptor Lake-S Client FSP; refer to SBOM section below](https://github.com/intel/FSP/tree/481ea7cf0bae0107c3e14aa746e52657647142f3/RaptorLakeFspBinPkg/Client/RaptorLakeS)
@@ -99,11 +99,11 @@ Test results for this release can be found
 [sha256.sig][msi_ms7d25_v1.1.3_ddr5_dev_signed.rom_sig]{.md-button}
 (msi_ms7d25_v1.1.3_ddr5_dev_signed)
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)
@@ -137,7 +137,7 @@ Test results for this release can be found
 
 ### Changed
 
-- [This is a Dasharo Entry Subscription release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
+- [This is a Dasharo Pro Package release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
 - [Updated microcode to newer version, refer to SBOM](https://github.com/coreboot/intel-microcode/commit/390edfb411ba7de8559ad40597c7acb6c6a1ea96)
 - [Updated ME to newer version, refer to SBOM](https://github.com/Dasharo/dasharo-blobs/tree/main/msi/ms7d25)
 
@@ -161,11 +161,11 @@ Test results for this release can be found
 
 ### Binaries
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 ### SBOM (Software Bill of Materials)
 

--- a/docs/variants/msi_z690/releases_heads.md
+++ b/docs/variants/msi_z690/releases_heads.md
@@ -15,7 +15,7 @@ Test results for this release can be found
 
 ### Changed
 
-- [This is a Dasharo Entry Subscription release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
+- [This is a Dasharo Pro Package release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
 - Heads Linux is used as a payload
 - [Updated Flash Descriptor to enlarge BIOS region; refer to SBOM section below](https://github.com/Dasharo/dasharo-blobs/tree/main/msi/ms7e06)
 - ME hardcoded to be HAP disabled for heads builds. Discrete SPI TPM in JTPM1
@@ -34,11 +34,11 @@ Test results for this release can be found
 [sha256][msi_ms7d25_v0.9.0_ddr5_heads.rom_hash]{.md-button}
 [sha256.sig][msi_ms7d25_v0.9.0_ddr5_heads.rom_sig]{.md-button}
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)

--- a/docs/variants/msi_z790/releases.md
+++ b/docs/variants/msi_z790/releases.md
@@ -41,7 +41,7 @@ Test results for this release can be found
 
 ### Changed
 
-- [This is a Dasharo Entry Subscription release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
+- [This is a Dasharo Pro Package release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
 - [Updated microcode to the newer version; refer to SBOM section below](https://github.com/coreboot/intel-microcode/commit/6788bb07eb5f9e9b83c31ea1364150fe898f450a)
 - [Updated ME to the newer version; refer to SBOM section below](https://github.com/Dasharo/dasharo-blobs/tree/main/msi/ms7e06)
 - [Updated Flash Descriptor to unlock regions; refer to SBOM section below](https://github.com/Dasharo/dasharo-blobs/tree/main/msi/ms7e06)
@@ -103,11 +103,11 @@ Test results for this release can be found
 [sha256.sig][msi_ms7e06_v0.9.1_ddr5_dev_signed.rom_sig]{.md-button}
 (msi_ms7e06_v0.9.1_ddr5_dev_signed)
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)
@@ -142,7 +142,7 @@ Test results for this release can be found
 
 ### Changed
 
-- [This is a Dasharo Entry Subscription release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
+- [This is a Dasharo Pro Package release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
 - [Updated microcode to newer version, refer to SBOM](https://github.com/coreboot/intel-microcode/commit/390edfb411ba7de8559ad40597c7acb6c6a1ea96)
 - [Updated ME to newer version, refer to SBOM](https://github.com/Dasharo/dasharo-blobs/tree/main/msi/ms7e06)
 
@@ -160,11 +160,11 @@ Test results for this release can be found
 
 ### Binaries
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 ### SBOM (Software Bill of Materials)
 

--- a/docs/variants/msi_z790/releases_heads.md
+++ b/docs/variants/msi_z790/releases_heads.md
@@ -23,7 +23,7 @@ Test results for this release can be found
 
 ### Changed
 
-- [This is a Dasharo Entry Subscription release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
+- [This is a Dasharo Pro Package release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
 - Heads Linux is used as a payload
 - [Updated Flash Descriptor to enlarge BIOS region; refer to SBOM section below](https://github.com/Dasharo/dasharo-blobs/tree/main/msi/ms7e06)
 - ME hardcoded to be HAP disabled for heads builds. Discrete SPI TPM in JTPM1
@@ -42,11 +42,11 @@ Test results for this release can be found
 [sha256][msi_ms7e06_v0.9.0_ddr5_heads.rom_hash]{.md-button}
 [sha256.sig][msi_ms7e06_v0.9.0_ddr5_heads.rom_sig]{.md-button}
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)

--- a/docs/variants/novacustom_nv4x_adl/releases_heads.md
+++ b/docs/variants/novacustom_nv4x_adl/releases_heads.md
@@ -26,11 +26,11 @@ Test results for this release can be found
 [sha256][novacustom_nv4x_adl_v0.9.1_heads.rom_hash]{.md-button}
 [sha256.sig][novacustom_nv4x_adl_v0.9.1_heads.rom_sig]{.md-button}
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)
@@ -53,7 +53,7 @@ Test results for this release can be found
 
 ### Changed
 
-- [This is a Dasharo Entry Subscription release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
+- [This is a Dasharo Pro Package release](https://docs.dasharo.com/dev-proc/versioning/#dasharo-entry-subscription-releases)
 - Heads Linux is used as a payload
 
 ### Known issues
@@ -68,11 +68,11 @@ Test results for this release can be found
 [sha256][novacustom_nv4x_adl_v0.9.0_heads.rom_hash]{.md-button}
 [sha256.sig][novacustom_nv4x_adl_v0.9.0_heads.rom_sig]{.md-button}
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)

--- a/docs/variants/overview.md
+++ b/docs/variants/overview.md
@@ -27,8 +27,8 @@ open-source firmware distribution.
 
 * Available at the 3mdeb online store:
 
-    - [Dasharo (coreboot+UEFI) Entry Subscription for Network Appliance](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1-year-dasharo-entry-subscription-for-network-appliance/)
-    - [Dasharo (coreboot+SeaBIOS) Entry Subscription for Network Appliance](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1-year-dasharo-entry-subscription-for-network-appliance-corebootseabios/)
+    - [Dasharo (coreboot+UEFI) Pro Package for Network Appliance](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1-year-dasharo-entry-subscription-for-network-appliance/)
+    - [Dasharo (coreboot+SeaBIOS) Pro Package for Network Appliance](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1-year-dasharo-entry-subscription-for-network-appliance-corebootseabios/)
 
 ## Laptops
 
@@ -47,7 +47,7 @@ open-source firmware distribution.
 
 * Available at the 3mdeb online store:
 
-    - [Dasharo (coreboot+UEFI) Entry Subscription for Laptops Upgrade to (coreboot+Heads)](https://shop.3mdeb.com/shop/dasharo-entry-subscription/dasharo-corebootuefi-entry-subscription-upgrade-to-corebootheads-for-laptop-users/)
+    - [Dasharo (coreboot+UEFI) Pro Package for Laptops Upgrade to (coreboot+Heads)](https://shop.3mdeb.com/shop/dasharo-entry-subscription/dasharo-corebootuefi-entry-subscription-upgrade-to-corebootheads-for-laptop-users/)
 
 ## Desktop
 
@@ -62,7 +62,7 @@ open-source firmware distribution.
 
 * Available at the 3mdeb online store:
 
-    - [Dasharo (coreboot+UEFI) Entry Subscription for Desktop](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1year-desktop/)
+    - [Dasharo (coreboot+UEFI) Pro Package for Desktop](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1year-desktop/)
 
 ## Workstation
 

--- a/docs/variants/pc_engines/faq.md
+++ b/docs/variants/pc_engines/faq.md
@@ -2,7 +2,7 @@
 <!-- markdownlint-disable-next-line MD013 -->
 ## What BIOS Version can I install with my Dasharo (coreboot+SeaBIOS) Subscription on an apu2/3/4/6 motherboard?
 
-When you subscribe to a Dasharo (coreboot+SeaBIOS) Entry Subscription for
+When you subscribe to a Dasharo (coreboot+SeaBIOS) Pro Package for
 Network Appliance, the BIOS version updates available to you are determined by
 Dasharo's release cycle and testing scope.
 
@@ -28,9 +28,9 @@ site at [Dasharo Release Documentation](https://docs.dasharo.com/variants/pc_eng
 <!-- markdownlint-disable-next-line MD013 -->
 ## How much would it cost me to switch my subscription for Network Appliance from already purchased (coreboot+UEFI) to (coreboot+SeaBIOS)?
 
-We can switch your subscription from [Dasharo (coreboot+UEFI) Entry Subscription
+We can switch your subscription from [Dasharo (coreboot+UEFI) Pro Package
 for Network Appliance](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1-year-dasharo-entry-subscription-for-network-appliance/)
-to the [Dasharo (coreboot+SeaBIOS) Entry Subscription for Network Appliance](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1-year-dasharo-entry-subscription-for-network-appliance-corebootseabios/)
+to the [Dasharo (coreboot+SeaBIOS) Pro Package for Network Appliance](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1-year-dasharo-entry-subscription-for-network-appliance-corebootseabios/)
 at no extra cost. This change can be made until the end of May 2024, but only if
 the purchase was made before the official [(coreboot+UEFI) release](https://docs.dasharo.com/variants/pc_engines/releases_uefi/)
 which occurred on 2024-04-02.

--- a/docs/variants/pc_engines/initial-deployment.md
+++ b/docs/variants/pc_engines/initial-deployment.md
@@ -34,9 +34,9 @@ seamlessly.
 - Ensure [Firmware Write Protection](https://github.com/pcengines/sortbootorder?tab=readme-ov-file#bios-wp-option)
   is disabled in sortbootorder
 - [Boot into Dasharo Tools Suite](https://docs.dasharo.com/dasharo-tools-suite/documentation/#running)
-- Enter your DES subscription credentials
+- Enter your DPP subscription credentials
 - Select `Install Dasharo firmware` to check for updates
-- When asked to select your firmware branch, select DES
+- When asked to select your firmware branch, select DPP
 
 When the deployment is finished, your device will reboot into Dasharo
 automatically.

--- a/docs/variants/pc_engines/overview.md
+++ b/docs/variants/pc_engines/overview.md
@@ -37,7 +37,7 @@ announcement](post-eol-fw-announcement.md), contact us
 [directly](mailto:contact@dasharo.com) or through [community
 chat](https://matrix.to/#/#dasharo:matrix.org). In 2024, the 3mdeb Dasharo Team
 was able to bring back PC Engines firmware in the form of Dasharo
-Pro/Enterprise Package (formerly known as Dasharo Entry Subscription) in two
+Pro/Enterprise Package (formerly known as Dasharo Pro Package) in two
 flavors [Dasharo
 (coreboot+SeaBIOS)](https://shop.3mdeb.com/shop/dasharo-entry-subscription/1-year-dasharo-entry-subscription-for-network-appliance-corebootseabios/)
 and [Dasharo

--- a/docs/variants/pc_engines/releases_seabios.md
+++ b/docs/variants/pc_engines/releases_seabios.md
@@ -67,13 +67,12 @@ Test results for this release can be found
 [sha256][pcengines_apu6_seabios_v24.05.00.01.rom_hash]{.md-button}
 [sha256.sig][pcengines_apu6_seabios_v24.05.00.01.rom_sig]{.md-button}
 
-This is a Dasharo Pro/Enterprise Package (formerly Dasharo Entry Subscription)
+This is a Dasharo Pro/Enterprise Package (formerly Dasharo Pro Package)
 Release. To obtain access to the pre-built binaries you will have to [get the
-Dasharo Pro/Enterprise Package (formerly Dasharo Entry
-Subscription)](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+Dasharo Pro/Enterprise Package (formerly Dasharo Pro Package)](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Pro/Enterprise Package (formerly Dasharo Entry
-Subscription) newsletter.
+subscription via Dasharo Pro/Enterprise Package (formerly Dasharo Pro Package
+) newsletter.
 
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)

--- a/docs/variants/pc_engines/releases_uefi.md
+++ b/docs/variants/pc_engines/releases_uefi.md
@@ -72,11 +72,11 @@ Test results for this platform can be found
 [sha256.sig][pcengines_apu6_v0.9.0_dev_signed.rom_sig]{.md-button}
 (pcengines_apu6_v0.9.0_dev_signed.rom)
 
-This is a Dasharo Entry Subscription Release. To obtain access to the pre-built
+This is a Dasharo Pro Package Release. To obtain access to the pre-built
 binaries you will have to
-[become the Dasharo Entry Subscription subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
+[become the Dasharo Pro Package subscriber](../../ways-you-can-help-us.md#become-a-dasharo-entry-subscription-subscriber).
 You will get the access to all of the firmware updates for the duration of the
-subscription via Dasharo Entry Subscription newsletter.
+subscription via Dasharo Pro Package newsletter.
 
 To verify binary integrity with hash and signature please follow the
 instructions in [Dasharo release signature verification](/guides/signature-verification)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -416,7 +416,7 @@ nav:
   - 'FAQ':
       - 'Introduction': osf-trivia-list/introduction.md
       - 'Dasharo': osf-trivia-list/dasharo.md
-      - 'Dasharo Entry Subscription': osf-trivia-list/dasharo-entry-subscription.md
+      - 'Dasharo Pro Package': osf-trivia-list/dasharo-entry-subscription.md
       - 'Dasharo Tools Suite': osf-trivia-list/dts.md
       - 'Deployment': osf-trivia-list/deployment.md
       - 'Firmware build process': osf-trolling-list/build_process.md


### PR DESCRIPTION
Also change all occurences of DES.
Didn't change any filenames or links.
There were occurences where the DES was referenced as a former name of DPP. I have kept them.