### PR TITLE
projects/trenchboot-aem*: fix TrenchBoot spelling

### DIFF
--- a/docs/projects/trenchboot-aem-v2.md
+++ b/docs/projects/trenchboot-aem-v2.md
@@ -2,7 +2,7 @@
 template: giscus.html
 ---
 
-# Trenchboot as Anti Evil Maid
+# TrenchBoot as Anti Evil Maid
 
 ## Abstract
 

--- a/docs/projects/trenchboot-aem.md
+++ b/docs/projects/trenchboot-aem.md
@@ -2,7 +2,7 @@
 template: giscus.html
 ---
 
-# Trenchboot as Anti Evil Maid
+# TrenchBoot as Anti Evil Maid
 
 **This is out of date and left here as a reference. Please use the [current
 version of the plan](trenchboot-aem-v2.md) for up-to-date information**


### PR DESCRIPTION
The documents used to have 'Trenchboot' in their titles, while the proper version is 'TrenchBoot'.