### PR TITLE
variants/supermicro_x11_lga1151_series: fix links to overview

### DIFF
--- a/docs/variants/supermicro_x11_lga1151_series/building-manual.md
+++ b/docs/variants/supermicro_x11_lga1151_series/building-manual.md
@@ -1,6 +1,6 @@
 # Supermicro X11 LGA1151 Series - building manual
 
-**Please read the [overview page](../overview.md) first!**
+**Please read the [overview page](overview.md) first!**
 
 <!--
 To build Dasharo compatible with Supermicro X11 LGA1151 Series, follow the

--- a/docs/variants/supermicro_x11_lga1151_series/faq.md
+++ b/docs/variants/supermicro_x11_lga1151_series/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-**Please read the [overview page](../overview.md) first!**
+**Please read the [overview page](overview.md) first!**
 
 ## How to identify my mainboard model?
 

--- a/docs/variants/supermicro_x11_lga1151_series/firmware-update.md
+++ b/docs/variants/supermicro_x11_lga1151_series/firmware-update.md
@@ -1,6 +1,6 @@
 # Firmware update
 
-**Please read the [overview page](../overview.md) first!**
+**Please read the [overview page](overview.md) first!**
 
 Following documentation describe process of Dasharo open-source firmware
 distribution update.

--- a/docs/variants/supermicro_x11_lga1151_series/hardware-matrix.md
+++ b/docs/variants/supermicro_x11_lga1151_series/hardware-matrix.md
@@ -1,6 +1,6 @@
 # Hardware configuration matrix
 
-**Please read the [overview page](../overview.md) first!**
+**Please read the [overview page](overview.md) first!**
 
 The tables below contain information about current components of the testing
 environment for Supermicro X11 LGA1151 Series available in 3mdeb testing

--- a/docs/variants/supermicro_x11_lga1151_series/recovery.md
+++ b/docs/variants/supermicro_x11_lga1151_series/recovery.md
@@ -1,6 +1,6 @@
 # Recovery
 
-**Please read the [overview page](../overview.md) first!**
+**Please read the [overview page](overview.md) first!**
 
 ---
 

--- a/docs/variants/supermicro_x11_lga1151_series/releases.md
+++ b/docs/variants/supermicro_x11_lga1151_series/releases.md
@@ -1,6 +1,6 @@
 # Dasharo compatible with Supermicro X11 LGA1151 Series
 
-**Please read the [overview page](../overview.md) first!**
+**Please read the [overview page](overview.md) first!**
 
 <!--
 Following Release Notes describe status of Open Source Firmware development for

--- a/docs/variants/supermicro_x11_lga1151_series/test-matrix.md
+++ b/docs/variants/supermicro_x11_lga1151_series/test-matrix.md
@@ -1,6 +1,6 @@
 # Test matrix - MSI Z690-A WIFI DDR4
 
-**Please read the [overview page](../overview.md) first!**
+**Please read the [overview page](overview.md) first!**
 
 ## About
 


### PR DESCRIPTION
All links to ../overview.md were pointing to top-level Dasharo overview, instead of X11 overview.md.