### PR TITLE
Add a note about NBT - PXE suites compatibility

### DIFF
--- a/docs/unified-test-documentation/dasharo-compatibility/315b-netboot-utilities.md
+++ b/docs/unified-test-documentation/dasharo-compatibility/315b-netboot-utilities.md
@@ -1,5 +1,12 @@
 # Dasharo Compatibility: Network boot utilities
 
+!!! note
+
+    This test suite is supported on Protectli releases with a
+    custom network boot menu. It is incompatible with the PXE
+    test suite. For most other releases the PXE test suite
+    should be used instead.
+
 ## Test cases common documentation
 
 **Test setup**


### PR DESCRIPTION
The NBT test suite is only used on Protectli devices which use a custom network boot menu. Other Dasharo releases should be tested with the PXE test suite. The suites are incompatible and will never both work on one release. This fact is not documented in the tests and may cause confusion and/or errors during release tests.