### PR TITLE
[RFC] docs/dev-proc/standard-release-process.md: Update release process

### DIFF
--- a/docs/dev-proc/standard-release-process.md
+++ b/docs/dev-proc/standard-release-process.md
@@ -9,17 +9,20 @@ should be maintained in that way.
 
 ## Process steps
 
-1. Checkout new branch `<platform>_rel_vX.Y.Z` from recent commit on `dasharo` -
-   to understand versioning scheme please read [Versioning](versioning.md)
-   section
-2. Merge current platform development branches to `<platform>_rel_vX.Y.Z`
-3. (Optional) Create a release candidate by tagging `<platform>_vX.Y.Z-rcN`
-4. Run platform regression test suite
-5. Fix all required issues and repeat from point 3 until fixed - this doesn't
-   mean all tests pass, this mean that approved set passed
-6. If results are accepted merge it to `dasharo` branch
-7. Add tag, which should trigger CI and publish binaries. Tag should be
-   annotated and signed. For example:
+1. Checkout new branch `<platform>_rel_vX.Y.Z-rcN` from recent commit on
+   `dasharo` - to understand versioning scheme please read
+   [Versioning](versioning.md) section
+2. Merge current platform development/bugfix branches to
+   `<platform>_rel_vX.Y.Z-rcN`.
+3. Merge `<platform>_rel_vX.Y.Z-rcN` branch it to `dasharo` branch
+4. Change the CONFIG_LOCALVERSION in coreboot configs appropriately and create
+   a release candidate by tagging `<platform>_vX.Y.Z-rcN`
+5. Run platform regression test suite.
+6. If all required tests passed, go to 8.
+7. Fix all required issues and repeat from point 1 until fixed.
+8. Change the CONFIG_LOCALVERSION in coreboot configs appropriately and add a
+   tag, which should trigger CI and publish binaries. Tag should be annotated,
+   signed and placed on the `dasharo` branch. For example:
 
     ```bash
     git tag -a -s -m "<platform>_vX.Y.Z" <platform>_vX.Y.Z


### PR DESCRIPTION
The idea here is to make it more clear that having a release branch doesn't necessarily fork in our favor for the following reasons:

1. Release may take sometimes months. When we finally merge the release branch to the main branch, a lot may have changed, so what lands in the main branch is far from what was released.
2. Due to 1, the code landing in the main branch may not even work anymore. This makes testing various changes between release cycles harder by requiring additional effort to restore working code base for given platform. Having a release branch for platform (and keeping it until final release) minimizes problems during release cycles, but only postpones the problems describes in the first two sentences. Do we really want to have a potentially broken code for platform right after release is out and code is merged? I don't think so.
3. IMO it is better to make smaller iterations with release candidates but merged to the main branch once some subset of bugs is fixed. Tags should only happen on the main branch after branch for RC is merged. Having all tags on the main branch opens the door for easier changelog generation based on git history.
4. Recent experiment with NVC release from a branch living for months showed its weaknesses. Constant rebasing is tiresome. Smaller iterations with RCs merged to main branch should help with that. There were also other problems, like unable to make quick changes and leverage CI to build binaries for external testing, due to never ending merge conflicts on release branch.
5. Sometimes (or often) there may be multiple concurrent release cycles. If each platform undergoing a release is living on a release branch, the disorder only grows. Especially when things get merged after release.
6. A very good example of disorder with branches is the OSFV repo. I saw the same platform being validated on multiple branches, each having different set of fixes. Figuring out what source given tests were run becomes harder. Fixes are scattered throughout many branches and pull requests, some of them also living for months (and probably suffer from similar problems described above). `main` branch isn't really main, but `develop` is instead. All of these little things contribute to the disorder and never-ending instability of the test environment. coreboot may end up the same way if we keep managing source like that.

As PR states, it is an RFC. Comments and constructive critique appreciated.

PS: I'm aware of different approaches being discussed, such as patch-queue and upstream-first.