### PR TITLE
Novacustom building manual: Suggest using 2021 container if build fails

### DIFF
--- a/docs/unified/novacustom/building-manual.md
+++ b/docs/unified/novacustom/building-manual.md
@@ -217,6 +217,14 @@
            coreboot/coreboot-sdk:2023-11-24_2731fa619b /bin/bash
         ```
 
+        - If the build commands ahead fail, try using an older container
+            ```bash
+            docker run --rm -it -u $UID \
+                -v $PWD:/home/coreboot/coreboot \
+                -w /home/coreboot/coreboot \
+                coreboot/coreboot-sdk:2021-09-23_b0d87f753c /bin/bash
+            ```
+
     1. Inside of the container, configure the build process:
 
         === "V540TU"


### PR DESCRIPTION
https://github.com/Dasharo/dasharo-issues/issues/1143
Temporary fix. NS5x_TGL v1.5.2 release does not build on 2023 version of the container. Possibly there might be more versions which can't be build according to the instructions.