### PR TITLE
Update Optiplex documentation

### DIFF
--- a/docs/variants/dell_optiplex/building-manual.md
+++ b/docs/variants/dell_optiplex/building-manual.md
@@ -34,6 +34,13 @@ the result binary using `cbfstool`. The methods are covered later on in the
     cd coreboot
     ```
 
+    Replace `vX.Y.Z` with a valid version, eg. `v0.1.1`:
+
+    ```bash
+    git fetch --tags
+    git checkout optiplex_7010_9010_vX.Y.Z
+    ```
+
     Checkout submodules:
 
     ```bash

--- a/docs/variants/dell_optiplex/building-manual.md
+++ b/docs/variants/dell_optiplex/building-manual.md
@@ -34,12 +34,6 @@ the result binary using `cbfstool`. The methods are covered later on in the
     cd coreboot
     ```
 
-    Replace `vX.Y.Z` with a valid version, eg. `v0.1.0`:
-
-    ```bash
-    git checkout optiplex_7010_9010_vX.Y.Z
-    ```
-
     Checkout submodules:
 
     ```bash

--- a/docs/variants/dell_optiplex/initial-deployment.md
+++ b/docs/variants/dell_optiplex/initial-deployment.md
@@ -120,7 +120,17 @@ binwalk -e O7010A29.exe -C .
 Assuming the extraction process was successful, you should now have an
 extracted UEFI image file, hidden under an unassuming name such as
 `65C10`. Deeper down the rabbit hole, you will now have to extract the
-blobs from this image using `uefi-firmware-parser`:
+blobs from this image using `uefi-firmware-parser`, a set of Python scripts 
+for parsing, extracting, and recreating UEFI firmware volumes. To install:
+
+```
+apt install python3-pip python3-venv
+python3 -m venv venv
+source venv/bin/activate
+pip install uefi-firmware==1.9
+```
+
+To extract the blobs (you may have to run the command twice):
 
 ```bash
  uefi-firmware-parser -e "_O7010A29.exe.extracted/65C10" -O
@@ -132,14 +142,14 @@ files. Now, let's copy them with more readable names for future reference:
 * EC firmware -
 
 `cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-
-42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-
-06091f67e0d3/section0.raw sch5545_ecfw.bin`
+42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw 
+sch5545_ecfw.bin`
 
 * BIOS ACM file -
 
 `cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-
-42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-
-21166be7e143/object-0.raw IVB_BIOSAC_PRODUCTION.bin`
+42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw 
+IVB_BIOSAC_PRODUCTION.bin`
 
 The SINIT file is fortunately available for download directly from Intel at
 [this url](https://cdrdv2.intel.com/v1/dl/getContent/630744).

--- a/docs/variants/dell_optiplex/initial-deployment.md
+++ b/docs/variants/dell_optiplex/initial-deployment.md
@@ -120,7 +120,7 @@ binwalk -e O7010A29.exe -C .
 Assuming the extraction process was successful, you should now have an
 extracted UEFI image file, hidden under an unassuming name such as
 `65C10`. Deeper down the rabbit hole, you will now have to extract the
-blobs from this image using `uefi-firmware-parser`, a set of Python scripts 
+blobs from this image using the `uefi-firmware` Python package, a set of scripts 
 for parsing, extracting, and recreating UEFI firmware volumes. To install:
 
 ```
@@ -145,14 +145,14 @@ files. Now, let's copy them with more readable names for future reference:
 cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw sch5545_ecfw.bin
 ```
 
-* BIOS ACM file -
+* BIOS ACM file (only necessary for TXT support) -
 
 ```
 cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw IVB_BIOSAC_PRODUCTION.bin
 ```
 
 The SINIT file is fortunately available for download directly from Intel at
-[this url](https://cdrdv2.intel.com/v1/dl/getContent/630744).
+[this url](https://cdrdv2.intel.com/v1/dl/getContent/630744) (again, only necessary for TXT support).
 
 ### Patching the binary
 

--- a/docs/variants/dell_optiplex/initial-deployment.md
+++ b/docs/variants/dell_optiplex/initial-deployment.md
@@ -124,7 +124,7 @@ blobs from this image using `uefi-firmware-parser`, a set of Python scripts
 for parsing, extracting, and recreating UEFI firmware volumes. To install:
 
 ```
-apt install python3-pip python3-venv
+apt install python3-venv python3-pip
 python3 -m venv venv
 source venv/bin/activate
 pip install uefi-firmware==1.9
@@ -141,15 +141,15 @@ files. Now, let's copy them with more readable names for future reference:
 
 * EC firmware -
 
-`cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-
-42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw 
-sch5545_ecfw.bin`
+```
+cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw sch5545_ecfw.bin
+```
 
 * BIOS ACM file -
 
-`cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-
-42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw 
-IVB_BIOSAC_PRODUCTION.bin`
+```
+cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw IVB_BIOSAC_PRODUCTION.bin
+```
 
 The SINIT file is fortunately available for download directly from Intel at
 [this url](https://cdrdv2.intel.com/v1/dl/getContent/630744).

--- a/docs/variants/dell_optiplex/initial-deployment.md
+++ b/docs/variants/dell_optiplex/initial-deployment.md
@@ -123,7 +123,7 @@ extracted UEFI image file, hidden under an unassuming name such as
 blobs from this image using the `uefi-firmware` Python package, a set of scripts 
 for parsing, extracting, and recreating UEFI firmware volumes. To install:
 
-```
+```bash
 apt install python3-venv python3-pip
 python3 -m venv venv
 source venv/bin/activate
@@ -141,13 +141,13 @@ files. Now, let's copy them with more readable names for future reference:
 
 * EC firmware -
 
-```
+```bash
 cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw sch5545_ecfw.bin
 ```
 
 * BIOS ACM file (only necessary for TXT support) -
 
-```
+```bash
 cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw IVB_BIOSAC_PRODUCTION.bin
 ```
 

--- a/docs/variants/dell_optiplex/initial-deployment.md
+++ b/docs/variants/dell_optiplex/initial-deployment.md
@@ -142,17 +142,22 @@ files. Now, let's copy them with more readable names for future reference:
 * EC firmware -
 
 ```bash
-cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw sch5545_ecfw.bin
+cp _O7010A29.exe.extracted/65C10_output/pfsobject/\
+    section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x50000/\
+    file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw sch5545_ecfw.bin
 ```
 
 * BIOS ACM file (only necessary for TXT support) -
 
 ```bash
-cp _O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw IVB_BIOSAC_PRODUCTION.bin
+cp _O7010A29.exe.extracted/65C10_output/pfsobject/\
+    section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x500000/\
+    file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw IVB_BIOSAC_PRODUCTION.bin
 ```
 
 The SINIT file is fortunately available for download directly from Intel at
-[this url](https://cdrdv2.intel.com/v1/dl/getContent/630744) (again, only necessary for TXT support).
+[this url](https://cdrdv2.intel.com/v1/dl/getContent/630744)
+(again, only necessary for TXT support).
 
 ### Patching the binary
 

--- a/docs/variants/dell_optiplex/initial-deployment.md
+++ b/docs/variants/dell_optiplex/initial-deployment.md
@@ -120,7 +120,7 @@ binwalk -e O7010A29.exe -C .
 Assuming the extraction process was successful, you should now have an
 extracted UEFI image file, hidden under an unassuming name such as
 `65C10`. Deeper down the rabbit hole, you will now have to extract the
-blobs from this image using the `uefi-firmware` Python package, a set of scripts 
+blobs from this image using the `uefi-firmware` Python package, a set of scripts
 for parsing, extracting, and recreating UEFI firmware volumes. To install:
 
 ```bash


### PR DESCRIPTION
Walking through the recovery process I noticed some issues with the Optiplex documentation, namely:

- The Optiplex branch has been merged with Dasharo and coreboot upstream, so no need to mention it in `building-manual.md`
- `uefi-firmware-parser` only works with version `1.9` for whatever reason. I'll include logs of the errors I encountered below if it's helpful.
- There was a typo in the file path for the EC firmware which made it annoying to copy and paste

Here's that error I encountered with the latest version of `uefi-firmware` (`1.11`):

```
  Dell PFSSection: 7439ed9e-70d3-4b65-9e33-1963a7ad3c37 spec 0x01 ts 0x00 type 0x00 version .8.1.72.3002 size 0x77b148 (7844168 bytes)
    ME Container type= 0x10 version= 0x20 size= 0x30 (48 bytes) entires= 23 flags= 0xfffffc01
Traceback (most recent call last):
  File "/home/user/Downloads/venv/bin/uefi-firmware-parser", line 196, in <module>
    _process_show_extract(firmware)
  File "/home/user/Downloads/venv/bin/uefi-firmware-parser", line 19, in _process_show_extract
    parsed_object.showinfo('')
  File "/home/user/Downloads/venv/lib/python3.11/site-packages/uefi_firmware/__init__.py", line 130, in showinfo
    self.objs[i].showinfo(ts, i)
  File "/home/user/Downloads/venv/lib/python3.11/site-packages/uefi_firmware/pfs.py", line 422, in showinfo
    section.showinfo("%s  " % ts)
  File "/home/user/Downloads/venv/lib/python3.11/site-packages/uefi_firmware/pfs.py", line 324, in showinfo
    sub_object.showinfo("%s  " % ts)
  File "/home/user/Downloads/venv/lib/python3.11/site-packages/uefi_firmware/base.py", line 198, in showinfo
    self.object.showinfo(ts)
  File "/home/user/Downloads/venv/lib/python3.11/site-packages/uefi_firmware/me.py", line 675, in showinfo
    partition.showinfo("  %s" % ts)
  File "/home/user/Downloads/venv/lib/python3.11/site-packages/uefi_firmware/me.py", line 625, in showinfo
    purple(self.structure.Name.decode("utf-8")), purple(self.structure.Owner),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe0 in position 0: invalid continuation byte
```

Hope this is helpful, thanks!