### PR TITLE
osf-trivia-list/dasharo-pro-package.md: fix nested lists

### DIFF
--- a/docs/osf-trivia-list/dasharo-pro-package.md
+++ b/docs/osf-trivia-list/dasharo-pro-package.md
@@ -10,19 +10,19 @@ you can download them:
    subscription. Look for an email from Dasharo that includes your subscription
    data. This email will contain several vital pieces of information:
 
-   - **Logs Key:** A key you might need for other operations or support.
-   - **Download Key:** A unique string that allows you to access the download area.
-   - **Password:** The password you'll need to access the files.
-   - **Expiration Date:** The date until your subscription is valid.
+    - **Logs Key:** A key you might need for other operations or support.
+    - **Download Key:** A unique string that allows you to access the download area.
+    - **Password:** The password you'll need to access the files.
+    - **Expiration Date:** The date until your subscription is valid.
 
 2. **Access the Download Page:** Open your web browser and navigate to the
    following URL:
 
-   ```txt
-   https://cloud.3mdeb.com/index.php/s/{download_key}
-   ```
+    ```txt
+    https://cloud.3mdeb.com/index.php/s/{download_key}
+    ```
 
-   Replace `{download_key}` with the download key provided in your email.
+    Replace `{download_key}` with the download key provided in your email.
 
 3. **Enter Your Password:** Once you visit the above link, you'll be prompted
    to enter a password. Use the password from your subscription email.


### PR DESCRIPTION
The indentation level was either not enough of missing, which has led mkdocs to misinterpret the formatting.

***

This fixes https://docs.dasharo.com/osf-trivia-list/dasharo-pro-package/ page which gets linked relatively frequently.  It looked wrong to me for a while and I realized why only recently.

**Before:**

![before](https://github.com/user-attachments/assets/5231eded-cf1d-4518-9e3a-915df7a9538f)

**After:**

![after](https://github.com/user-attachments/assets/8c25b262-a7e0-4242-84de-27210b7efb4c)
