### PR TITLE
docs/variants/overview.md: add missing laptops shop product

### DIFF
--- a/docs/variants/overview.md
+++ b/docs/variants/overview.md
@@ -47,8 +47,8 @@ open-source firmware distribution.
 
 * Available at the 3mdeb online store:
 
-    - [Dasharo (coreboot+UEFI) Pro Package for Laptops Upgrade to (coreboot+Heads) for NV41PZ](https://shop.3mdeb.com/shop/dasharo-pro-package/dasharo-corebootuefi-entry-subscription-upgrade-to-corebootheads-for-laptop-users/)
-    - [Dasharo (coreboot+UEFI) Pro Package for Laptops Upgrade to (coreboot+Heads) for V560TU](https://shop.3mdeb.com/shop/dasharo-pro-package/dasharo-corebootuefi-transition-to-corebootheads-for-v560tu-laptops/)
+    - [Dasharo (coreboot+UEFI) transition to (coreboot+Heads) for NV41PZ Laptops](https://shop.3mdeb.com/shop/dasharo-pro-package/dasharo-corebootuefi-entry-subscription-upgrade-to-corebootheads-for-laptop-users/)
+    - [Dasharo (coreboot+UEFI) transition to (coreboot+Heads) for V560TU Laptops](https://shop.3mdeb.com/shop/dasharo-pro-package/dasharo-corebootuefi-transition-to-corebootheads-for-v560tu-laptops/)
 
 ## Desktop
 

--- a/docs/variants/overview.md
+++ b/docs/variants/overview.md
@@ -47,7 +47,8 @@ open-source firmware distribution.
 
 * Available at the 3mdeb online store:
 
-    - [Dasharo (coreboot+UEFI) Pro Package for Laptops Upgrade to (coreboot+Heads)](https://shop.3mdeb.com/shop/dasharo-pro-package/dasharo-corebootuefi-entry-subscription-upgrade-to-corebootheads-for-laptop-users/)
+    - [Dasharo (coreboot+UEFI) Pro Package for Laptops Upgrade to (coreboot+Heads) for NV41PZ](https://shop.3mdeb.com/shop/dasharo-pro-package/dasharo-corebootuefi-entry-subscription-upgrade-to-corebootheads-for-laptop-users/)
+    - [Dasharo (coreboot+UEFI) Pro Package for Laptops Upgrade to (coreboot+Heads) for V560TU](https://shop.3mdeb.com/shop/dasharo-pro-package/dasharo-corebootuefi-transition-to-corebootheads-for-v560tu-laptops/)
 
 ## Desktop
 


### PR DESCRIPTION
This PR introduces changes to improve the shop user experience. The shop section about DPP laptops may mislead users who have laptops other than NV41PZ. The proposed changes extend the product list to include the newest DPP for laptops (transition) for V560TU: https://shop.3mdeb.com/shop/dasharo-pro-package/dasharo-corebootuefi-transition-to-corebootheads-for-v560tu-laptops/