### PR TITLE
protectli/overview.md: Fix link to 4670 revision check

### DIFF
--- a/docs/unified/protectli/overview.md
+++ b/docs/unified/protectli/overview.md
@@ -60,8 +60,7 @@
     * VP4650 - Intel Core i5-10210U
     * VP4670 - Intel Core i7-10810U (both v1 and v2 versions, see the
     [Intel FSP repo for details](
-        https://github.com/intel/FSP/tree/master/
-        CometLakeFspBinPkg#differentiating-cometlake1-and-cometlake2))
+        https://github.com/intel/FSP/tree/master/CometLakeFspBinPkg#differentiating-cometlake1-and-cometlake2))
 
     > Starting with Dasharo [v1.0.19](../../variants/protectli_vp46xx/releases.md#v1019-2022-12-08)
     > Intel ME (Management Engine) is


### PR DESCRIPTION
Breaking the line inserted four spacebars into the URL which made it return 404