### PR TITLE
qemu_q35/releases.md: Add v0.2.1 release notes from dasharo/dasharo

### DIFF
--- a/docs/variants/qemu_q35/releases.md
+++ b/docs/variants/qemu_q35/releases.md
@@ -1,7 +1,45 @@
-# Release Notes
+# emulation qemu_q35 Dasharo Release Notes
 
-Following Release Notes describe status of Open Source Firmware development for
+Following Release Notes describe status of open-source firmware development for
 QEMU Q35 (Emulator).
+
+For details about our release process please read
+[Dasharo Standard Release Process](../../dev-proc/standard-release-process.md).
+
+## v0.2.1 - 2025-05-23
+
+Test results for this release can be found
+[here](https://github.com/Dasharo/osfv-results/blob/main/boards/QEMU/Q35/v0.2.1_results.csv).
+
+### Changed
+
+- The Local APIC timer is now used instead of the HPET
+
+### Fixed
+
+- The time in the firmware flows at a correct pace now resulting in much
+  quicker boot times.
+
+### Known issues
+
+- [Measured Boot PCR values don't match the TPM measurement log](https://github.com/Dasharo/dasharo-issues/issues/1354)
+
+### Binaries
+
+[qemu_q35_v0.2.1.rom][qemu_q35_v0.2.1.rom_file]{.md-button}
+[sha256][qemu_q35_v0.2.1.rom_hash]{.md-button}
+[sha256.sig][qemu_q35_v0.2.1.rom_sig]{.md-button}
+
+### SBOM (Software Bill of Materials)
+
+- [Dasharo coreboot fork based on 4.18 revision b8e6b3eb](https://github.com/Dasharo/coreboot/tree/b8e6b3eb)
+    + [License](https://github.com/Dasharo/coreboot/blob/b8e6b3eb/COPYING)
+- [Dasharo EDKII fork based on edk2-stable202002 revision e8cd1856](https://github.com/Dasharo/edk2/tree/e8cd1856)
+    + [License](https://github.com/Dasharo/edk2/blob/e8cd1856/License.txt)
+
+[qemu_q35_v0.2.1.rom_file]: https://dl.3mdeb.com/open-source-firmware/Dasharo/qemu_q35/v0.2.1/qemu_q35_v0.2.1.rom
+[qemu_q35_v0.2.1.rom_hash]: https://dl.3mdeb.com/open-source-firmware/Dasharo/qemu_q35/v0.2.1/qemu_q35_v0.2.1.rom.sha256
+[qemu_q35_v0.2.1.rom_sig]: https://dl.3mdeb.com/open-source-firmware/Dasharo/qemu_q35/v0.2.1/qemu_q35_v0.2.1.rom.sha256.sig
 
 ## v0.2.0 - 2024-06-26
 

--- a/docs/variants/qemu_q35/releases.md
+++ b/docs/variants/qemu_q35/releases.md
@@ -26,20 +26,17 @@ Test results for this release can be found
 
 ### Binaries
 
-[qemu_q35_v0.2.1.rom][qemu_q35_v0.2.1.rom_file]{.md-button}
-[sha256][qemu_q35_v0.2.1.rom_hash]{.md-button}
-[sha256.sig][qemu_q35_v0.2.1.rom_sig]{.md-button}
+Binaries can be found in
+[GitHub release](https://github.com/Dasharo/coreboot/releases/tag/qemu_q35_v0.2.1).
 
 ### SBOM (Software Bill of Materials)
 
-- [Dasharo coreboot fork based on 4.18 revision b8e6b3eb](https://github.com/Dasharo/coreboot/tree/b8e6b3eb)
+- [Dasharo coreboot fork based on 25.03 revision b8e6b3eb](https://github.com/Dasharo/coreboot/tree/b8e6b3eb)
     + [License](https://github.com/Dasharo/coreboot/blob/b8e6b3eb/COPYING)
-- [Dasharo EDKII fork based on edk2-stable202002 revision e8cd1856](https://github.com/Dasharo/edk2/tree/e8cd1856)
+- [Dasharo EDKII fork based on edk2-stable202502 revision e8cd1856](https://github.com/Dasharo/edk2/tree/e8cd1856)
     + [License](https://github.com/Dasharo/edk2/blob/e8cd1856/License.txt)
-
-[qemu_q35_v0.2.1.rom_file]: https://dl.3mdeb.com/open-source-firmware/Dasharo/qemu_q35/v0.2.1/qemu_q35_v0.2.1.rom
-[qemu_q35_v0.2.1.rom_hash]: https://dl.3mdeb.com/open-source-firmware/Dasharo/qemu_q35/v0.2.1/qemu_q35_v0.2.1.rom.sha256
-[qemu_q35_v0.2.1.rom_sig]: https://dl.3mdeb.com/open-source-firmware/Dasharo/qemu_q35/v0.2.1/qemu_q35_v0.2.1.rom.sha256.sig
+- [Dasharo iPXE fork based on 2024.07 revision 63ed3e35](https://github.com/Dasharo/ipxe/tree/63ed3e35)
+    + [License](https://github.com/Dasharo/ipxe/blob/63ed3e35/COPYING.GPLv2)
 
 ## v0.2.0 - 2024-06-26
 


### PR DESCRIPTION
The v0.2.0 release was not created using dasharo/dasharo, so it had to be manually copied from the previous version of the releases.md file