### PR TITLE
docs/variants/dell_optiplex/overview.md: distinguish hardware versions

### DIFF
--- a/docs/variants/dell_optiplex/overview.md
+++ b/docs/variants/dell_optiplex/overview.md
@@ -15,9 +15,33 @@ documentation._
 
 ## Dell OptiPlex 7010/9010 SFF
 
-Dell OptiPlex 7010/9010 SFF is a small SOHO desktop computer, sometimes used
-as a
-[firewall or NAS](https://www.reddit.com/r/homelabsales/comments/uzspg3/comment/iadcyb6/?utm_source=share&utm_medium=web2x&context=3).
+OptiPlex is a computer series by Dell aimed at office workloads coming in
+different form factors and quality levels.
+
+Dasharo supports the IvyBridge equipped 7010 and 9010 SFF models which share
+the same board. There exists also three other versions sharing most of the
+internals but differ a bit regarding expansion possibilities. Additionally the
+Precision T1650 has essentially the same board as the MT featuring a workstation
+grade C216 chipset.
+
+|                 | MT - Medium Tower           | DT - Desktop                | SFF - Small Form Factor | USFF - Ultra Small Form Factor |
+| --------------- | --------------------------- | --------------------------- | ----------------------- | ------------------------------ |
+| UDIMM           | 4                           | 4                           | 4                       | 2                              |
+| USB 2           | 2 Front, 4 Back, 1 Internal | 2 Front, 4 Back, 1 Internal | 2 Front, 4 Back         | 2 Back                         |
+| USB 3           | 2 Front, 2 Back             | 2 Front, 2 Back             | 2 Front, 2 Back         | 2 Front, 2 Back                |
+| SATA 2.0        | 2                           | 1                           | 1                       | -                              |
+| SATA 3.0        | 2                           | 2                           | 2                       | 2                              |
+| Expansion Cards | 4 full height               | 4 half height               | 2 half height           | 1 MiniPCIe half height         |
+| PCI 2.3         | 1                           | 1                           | -                       | -                              |
+| PCIe 2.0        | 1x4, 1x1                    | 1x4, 1x1                    | 1x4                     | 1x                             |
+| PCIe 3.0        | 1x16                        | 1x16                        | 1x16                    | -                              |
+| Height          | 36.00 cm                    | 36.00 cm                    | 29.00 cm                | 23.70 cm                       |
+| Width           | 17.50 cm                    | 10.20 cm                    | 9.30 cm                 | 6.50 cm                        |
+| Depth           | 41.70 cm                    | 41.00 cm                    | 31.20 cm                | 24.00 cm                       |
+| Weight          | 9.40 kg                     | 7.90 kg                     | 6.00 kg                 | 3.30 kg                        |
+
+Note: There also exists the OptiPlex Tower 7010 which has nothing to do with this
+IvyBridge series from a firmware point of view.
 
 If you wish to build, perform initial deployment, update or recover your setup,
 please refer to [documentation](#documentation) sections.
@@ -61,3 +85,9 @@ again at future events.
 * [Dell OptiPlex and coreboot - a story about porting cursed hardware (part 1)](https://blog.3mdeb.com/2020/2020-06-24-dell-optiplex-port/)
 * [Dell OptiPlex and coreboot - a story about porting cursed hardware (part 2)](https://blog.3mdeb.com/2021/2021-06-01-optiplex_part2/)
 * [Dasharo for Dell OptiPlex 7010 / 9010](https://blog.3mdeb.com/2021/2021-11-26-optiplex-dasharo/)
+* 7010: [Dell-Support](https://www.dell.com/support/product-details/en-us/product/optiplex-7010/resources/manuals),
+ [Technical Guidebook](https://i.dell.com/sites/doccontent/shared-content/data-sheets/en/Documents/OptiPlex_7010_Technical_Guidebook.pdf),
+ [3mdeb-Shop](https://shop.3mdeb.com/shop/dasharo-supported-hardware/dasharo-dell-optiplex-7010/)
+* 9010: [Dell-Support](https://www.dell.com/support/product-details/en-us/product/optiplex-9010/resources/manuals),
+ [Technical Guidebook](https://i.dell.com/sites/doccontent/shared-content/data-sheets/en/Documents/OptiPlex_9010_Technical_Guidebook.pdf),
+ [3mdeb-Shop](https://shop.3mdeb.com/shop/dasharo-supported-hardware/dasharo-dell-optiplex-9010-sff-i7-3770-8gb-32gb-ram/)


### PR DESCRIPTION
As discussed in https://github.com/Dasharo/dasharo-issues/issues/1427
Builds and looks fine, no new warning or info labels introduced

I didn't change the picture yet because of
1. copyright - I dont' have the machines so I can't take pictures
2. confusion - the picture in the [doc](https://docs.dasharo.com/variants/dell_optiplex/overview/) and at the [shop](https://shop.3mdeb.com/shop/dasharo-supported-hardware/dasharo-dell-optiplex-7010/) both show the DT version and @pietrushnic [says](https://github.com/Dasharo/dasharo-issues/issues/1182#issuecomment-3073053710) that the
> terminology [here](https://docs.dasharo.com/variants/overview/) is different than Dell, so what we mean by desktop or workstation does not have to reflect what the vendor meant.

but [codewise](https://github.com/Dasharo/coreboot/blob/36244307c6ff2e6e27a43d44702a92011b7ace69/src/mainboard/dell/snb_ivb_workstations/variants/optiplex_9010_sff/overridetree.cb) it's really the SFF version. Are these pictures just show the wrong version all the time?