### PR TITLE
docs: dasharo-tools-suite: overview.md: make DTS key inf generic

### DIFF
--- a/docs/dasharo-tools-suite/overview.md
+++ b/docs/dasharo-tools-suite/overview.md
@@ -13,7 +13,9 @@ the initial deployment, even when no OS is currently installed.
   repository pages now collects all versions of `DTS` image on `Releases` tab.
   To verify binary integrity with hash and signature please go there, grab
   latest release and follow the instructions in [Dasharo release signature
-  verification](../guides/signature-verification.md) using [this key](https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/8fbbaa4461c75c932a1bbc905a8692518331b415/dasharo/dasharo_tools_suite/dasharo-tools-suite-open-source-software-release-2.6.x-signing-key-pub.asc)
+  verification](../guides/signature-verification.md) using the key for the
+  appropriate DTS release [from
+  here.](https://github.com/3mdeb/3mdeb-secpack/tree/master/dasharo/dasharo_tools_suite)
 
 * [Building](documentation/building.md) - describes how to build DTS.
 * [Running](documentation/running.md) - describes how to run DTS.


### PR DESCRIPTION
For two reasons:
* Not to update it every time the key is being changed.
* Somebody may use older DTS releases and may want to find the key for them too.