### PR TITLE
protectli/initial-deployment.md: Unify for all models

### DIFF
--- a/docs/unified/protectli/initial-deployment.md
+++ b/docs/unified/protectli/initial-deployment.md
@@ -19,155 +19,20 @@ flashrom -p internal -r dump.rom
 
 ## Flashing Dasharo
 
-=== "FW6"
+To flash Dasharo on the platform, execute the following command - replace `[path]`
+with the path to the Dasharo image you want to flash:
 
-    To flash Dasharo on the platform, execute the following command - replace `[path]`
-    with the path to the Dasharo image you want to flash, e.g. `protectli_fw6_DF_v1.0.14.rom`.
+```bash
+sudo flashrom -p internal -w [path]
+```
 
-    ```bash
-    sudo flashrom -p internal -w [path] --ifd -i bios
-    ```
-
-    After successful operation reboot the platform.
-
-=== "V1000-series"
-
-    To flash Dasharo on the platform, execute the following command - replace
-    `[path]` with the path to the Dasharo image you want to flash, e.g.
-    `protectli_vault_V1210_v0.9.3.rom`.
-
-    ```bash
-    flashrom -p internal -w [path] --ifd -i bios
-    ```
-
-    This will flash the BIOS region only. After the operation is successful,
-    reboot the platform.
-
-=== "VP4630/VP4650/VP4670"
-
-    To flash Dasharo on the platform, execute the following command -
-    replace `[path]` with the path to the Dasharo image you want to flash, e.g.
-    `protectli_vault_cml_v1.0.13.rom`.
-
-    ```bash
-    flashrom -p internal -w [path]
-    ```
-
-    This will flash the full image, including the Intel ME. The operation
-    requires a hard reset of the platform. To perform a hard reset:
+This will flash the full image, including the Intel ME. The operation
+requires a hard reset of the platform. To perform a hard reset:
 
     1. Power off the platform. Note, it may not power off completely due to
         flashed ME.
     2. Disconnect power supply from the board when OS finishes all tasks after
         power off (the screen goes dark or black).
-    3. Disconnect the RTC/CMOS battery OR clear the CMOS using the pin header
-        located near memory slots. Wait about half a minute (unshort the pins).
+    3. Disconnect the RTC/CMOS battery, connect it back after a couple seconds.
     4. Connect the power supply back.
-    5. The platform should power on normally now. You can connect the battery
-        back if it was disconnected.
-
-=== "VP6630/VP6650/VP6670"
-
-    To flash Dasharo on the platform, execute the following command - replace
-    `[path]` with the path to the Dasharo image you want to flash, e.g.
-    `protectli_vp66xx_v0.9.0.rom`.
-
-    ```bash
-    flashrom -p internal -w [path] --ifd -i bios
-    ```
-
-    This will flash the BIOS region only. After the operation is successful,
-    reboot the platform.
-
-=== "VP2410"
-
-    To flash Dasharo on the platform, execute the following command -
-    replace `[path]` with the path to the Dasharo image you want to flash,
-    e.g. `protectli_vault_glk_v1.0.15.rom`.
-
-    If stock firmware is currently installed:
-
-    ```bash
-    flashrom -p internal -w [path]
-    ```
-
-    If Dasharo is currently installed, only the COREBOOT and IFWI partitions
-    of the flash needs to be updated. Flash it using the following command:
-
-    ```bash
-    flashrom -p internal -w protectli_vault_glk_v1.0.15.rom --fmap -i COREBOOT -i IFWI
-    ```
-
-    This command also preserves Dasharo UEFI settings and the boot order.
-
-=== "VP2420"
-
-    To flash Dasharo on the platform, execute the following command - replace
-    `[path]` with the path to the Dasharo image you want to flash, e.g.
-    `protectli_vault_ehl_v1.0.0.rom`.
-
-    If stock firmware is currently installed:
-
-    ```bash
-    flashrom -p internal -w [path] --ifd -i bios
-    ```
-
-    If Dasharo is currently installed, only the `RW_SECTION_A` partition of the
-    flash needs to be updated. Flash it using the following command:
-
-    ```bash
-    flashrom -p internal -w protectli_vault_ehl_v1.x.y.rom --fmap -i RW_SECTION_A
-    ```
-
-    This command also preserves Dasharo UEFI settings and the boot order.
-
-=== "VP2430"
-
-    To flash Dasharo on the platform, execute the following command - replace
-    `[path]` with the path to the Dasharo image you want to flash, e.g.
-    `protectli_vp2430_v0.9.0.rom`.
-
-    If stock firmware is currently installed:
-
-    ```bash
-    flashrom -p internal -w [path] --ifd -i bios
-    ```
-
-    If Dasharo is currently installed, only the `RW_SECTION_A` partition of the
-    flash needs to be updated. Flash it using the following command:
-
-    ```bash
-    flashrom -p internal -w protectli_vp2430_v0.9.0.rom --fmap -i RW_SECTION_A
-    ```
-
-    This command also preserves Dasharo UEFI settings and the boot order.
-
-=== "VP3210/VP3230"
-
-    To flash Dasharo on the platform, execute the following command -
-    replace `[path]` with the path to the Dasharo image you want to flash,
-    e.g. `protectli_vp32xx_v0.9.0.rom`:
-
-    ```bash
-    flashrom -p internal -w protectli_vp32xx_v0.9.0.rom
-    ```
-=== "VP2440"
-
-    To flash Dasharo on the platform, execute the following command - replace
-    `[path]` with the path to the Dasharo image you want to flash, e.g.
-    `protectli_vp2440_v0.9.0.rom`.
-
-    If stock firmware is currently installed:
-
-    ```bash
-    flashrom -p internal -w [path] --ifd -i bios
-    ```
-
-    If Dasharo is currently installed, only the `RW_SECTION_A` partition of the
-    flash needs to be updated. Flash it using the following command:
-
-    ```bash
-    flashrom -p internal -w protectli_vp2440_v0.9.0.rom --fmap -i RW_SECTION_A
-    ```
-
-    This command also preserves Dasharo UEFI settings and the boot order.
+    5. The platform should power on normally now.


### PR DESCRIPTION
The newest releases for every models were checked if they contain all the required flash regions and are not empty by:
- unpacking using `ifdtool -X`
- checking if not empty using `binwalk -E` Checked binaries:
- FW6C v1.0.14 - contains non-empty fd, bios, me
- V1210 v0.9.3 - contains non-empty fd, bios, me
- v1211 v0.9.3 - contains non-empty fd, bios, me
- v1410  v0.9.3 - contains non-empty fd, bios, me
- V1610 v0.9.3 - contains non-empty fd, bios, me
- VP2410 v1.1.1 - contains non-empty fd, bios (me not supported)
- VP2420 v1.2.1 - contains non-empty fd, bios, me
- VP2430 v0.9.0 - contans non-empty fd, bios, me
- VP2440 v0.9.0 - contains non-empty fd, bios, me
- VP32xx v0.9.0 - contains non-empty fd, bios, me
- VP46xx v1.2.0 - contains non-empty fd, bios, me
- VP66xx v0.9.2 - contains non-empty fd, bios, me

Logs from the checks:
[checks.log](https://github.com/user-attachments/files/22612463/checks.log)
