### PR TITLE
docs(dell): align SFF naming to OptiPlex 7010/9010

### DIFF
--- a/docs/variants/dell_optiplex/initial-deployment.md
+++ b/docs/variants/dell_optiplex/initial-deployment.md
@@ -12,7 +12,7 @@ for following models
 :-------:|:-----:|
 |Dell    | OptiPlex 7010 SFF |
 |Dell    | OptiPlex 7010 DT |
-|Dell    | OptiPlex 9010 SFF |
+|Dell    | OptiPlex 7010/9010 SFF |
 |Dell    | OptiPlex 9010 MT |
 
 </center>

--- a/docs/variants/dell_optiplex/recovery.md
+++ b/docs/variants/dell_optiplex/recovery.md
@@ -14,7 +14,7 @@ open-source firmware. Following procedure is supported for following models
 :-------:|:-----:|
 |Dell    | OptiPlex 7010 SFF |
 |Dell    | OptiPlex 7010 DT |
-|Dell    | OptiPlex 9010 SFF |
+|Dell    | OptiPlex 7010/9010 SFF |
 
 </center>
 


### PR DESCRIPTION
## Summary
Follow-up docs alignment for #1182: make SFF naming consistent with shared 7010/9010 support.

## Changes
Updated two entry tables to use:
- `OptiPlex 7010/9010 SFF`

Files:
- `docs/variants/dell_optiplex/initial-deployment.md`
- `docs/variants/dell_optiplex/recovery.md`

## Why
Core support and variant overview already describe shared 7010/9010 SFF scope. This avoids user confusion by making deployment/recovery tables consistent.

Related issue: https://github.com/Dasharo/dasharo-issues/issues/1182
