### PR TITLE
docs(dell): deduplicate overlapping SFF support rows

### DIFF
--- a/docs/variants/dell_optiplex/initial-deployment.md
+++ b/docs/variants/dell_optiplex/initial-deployment.md
@@ -10,7 +10,6 @@ for following models
 
 | Vendor | Model |
 :-------:|:-----:|
-|Dell    | OptiPlex 7010 SFF |
 |Dell    | OptiPlex 7010 DT |
 |Dell    | OptiPlex 9010 SFF |
 |Dell    | OptiPlex 9010 MT |

--- a/docs/variants/dell_optiplex/recovery.md
+++ b/docs/variants/dell_optiplex/recovery.md
@@ -12,7 +12,6 @@ open-source firmware. Following procedure is supported for following models
 
 | Vendor | Model |
 :-------:|:-----:|
-|Dell    | OptiPlex 7010 SFF |
 |Dell    | OptiPlex 7010 DT |
 |Dell    | OptiPlex 9010 SFF |
 


### PR DESCRIPTION
## Summary
Follow-up cleanup for #1182: deduplicate overlapping SFF entries in deployment/recovery support tables.

## Changes
Removed redundant rows:
- `OptiPlex 7010 SFF`

Kept shared row:
- `OptiPlex 7010/9010 SFF`

Files:
- `docs/variants/dell_optiplex/initial-deployment.md`
- `docs/variants/dell_optiplex/recovery.md`

## Why
After naming alignment to `7010/9010 SFF`, keeping both rows creates duplicate/ambiguous support statements.
This PR keeps the table concise and consistent.

Related issue: https://github.com/Dasharo/dasharo-issues/issues/1182
