### PR TITLE
docs(dell): clarify current support scope for 7010/9010

### DIFF
--- a/docs/variants/dell_optiplex/overview.md
+++ b/docs/variants/dell_optiplex/overview.md
@@ -26,8 +26,9 @@ grade C216 chipset.
 
 ### Current support scope
 
-At the moment, Dasharo deployment/recovery support for this variant is focused on the
-**OptiPlex 7010/9010 SFF shared baseline**. Other form factors
+At the moment, Dasharo deployment/recovery support for this variant
+is focused on the **OptiPlex 7010/9010 SFF shared baseline**.
+Other form factors
 (DT/MT/USFF) may share parts of the platform but require separate validation
 work before being treated as fully supported in the same way.
 

--- a/docs/variants/dell_optiplex/overview.md
+++ b/docs/variants/dell_optiplex/overview.md
@@ -24,7 +24,6 @@ internals but differ a bit regarding expansion possibilities. Additionally the
 Precision T1650 has essentially the same board as the MT featuring a workstation
 grade C216 chipset.
 
-
 ### Current support scope
 
 At the moment, Dasharo deployment/recovery support for this variant is focused on the

--- a/docs/variants/dell_optiplex/overview.md
+++ b/docs/variants/dell_optiplex/overview.md
@@ -27,7 +27,8 @@ grade C216 chipset.
 ### Current support scope
 
 At the moment, Dasharo deployment/recovery support for this variant is focused on the
-**OptiPlex 7010/9010 SFF shared baseline**. Other form factors (DT/MT/USFF) may share
+**OptiPlex 7010/9010 SFF shared baseline**. Other form factors
+(DT/MT/USFF) may share parts of the platform but require
 parts of the platform but require separate validation work before being treated as
 fully supported in the same way.
 

--- a/docs/variants/dell_optiplex/overview.md
+++ b/docs/variants/dell_optiplex/overview.md
@@ -24,6 +24,14 @@ internals but differ a bit regarding expansion possibilities. Additionally the
 Precision T1650 has essentially the same board as the MT featuring a workstation
 grade C216 chipset.
 
+
+### Current support scope
+
+At the moment, Dasharo deployment/recovery support for this variant is focused on the
+**OptiPlex 7010/9010 SFF shared baseline**. Other form factors (DT/MT/USFF) may share
+parts of the platform but require separate validation work before being treated as
+fully supported in the same way.
+
 |                 | MT - Medium Tower           | DT - Desktop                | SFF - Small Form Factor | USFF - Ultra Small Form Factor |
 | --------------- | --------------------------- | --------------------------- | ----------------------- | ------------------------------ |
 | UDIMM           | 4                           | 4                           | 4                       | 2                              |

--- a/docs/variants/dell_optiplex/overview.md
+++ b/docs/variants/dell_optiplex/overview.md
@@ -29,7 +29,6 @@ grade C216 chipset.
 At the moment, Dasharo deployment/recovery support for this variant is focused on the
 **OptiPlex 7010/9010 SFF shared baseline**. Other form factors
 (DT/MT/USFF) may share parts of the platform but require
-parts of the platform but require separate validation work before being treated as
 fully supported in the same way.
 
 |                 | MT - Medium Tower           | DT - Desktop                | SFF - Small Form Factor | USFF - Ultra Small Form Factor |

--- a/docs/variants/dell_optiplex/overview.md
+++ b/docs/variants/dell_optiplex/overview.md
@@ -28,8 +28,8 @@ grade C216 chipset.
 
 At the moment, Dasharo deployment/recovery support for this variant is focused on the
 **OptiPlex 7010/9010 SFF shared baseline**. Other form factors
-(DT/MT/USFF) may share parts of the platform but require
-fully supported in the same way.
+(DT/MT/USFF) may share parts of the platform but require separate validation
+work before being treated as fully supported in the same way.
 
 |                 | MT - Medium Tower           | DT - Desktop                | SFF - Small Form Factor | USFF - Ultra Small Form Factor |
 | --------------- | --------------------------- | --------------------------- | ----------------------- | ------------------------------ |


### PR DESCRIPTION
## Summary
Add an explicit support-scope clarification to reduce ambiguity in OptiPlex 7010/9010 docs.

## Change
- `docs/variants/dell_optiplex/overview.md`
- Added **Current support scope** section stating that deployment/recovery support is currently focused on the shared 7010/9010 SFF baseline, while other form factors need separate validation.

## Why
Issue #1182 discussion highlights repeated confusion around form-factor overlap vs validated support scope. This note makes the current state explicit for users.

Related issue: https://github.com/Dasharo/dasharo-issues/issues/1182
