### PR TITLE
docs(dell): add validation-scope note to test matrix

### DIFF
--- a/docs/variants/dell_optiplex/test-matrix.md
+++ b/docs/variants/dell_optiplex/test-matrix.md
@@ -8,10 +8,9 @@ subjected from before the release of the new binary.
 
 
 !!! note
-
-    Current validation baseline for this variant tracks the shared **OptiPlex
-    7010/9010 SFF** support scope. Results for other form factors (DT/MT/USFF)
-    may require separate validation scope definitions.
+    Current validation baseline for this variant tracks the shared
+    **OptiPlex 7010/9010 SFF** support scope. Results for other form factors
+    (DT/MT/USFF) may require separate validation scope definitions.
 
 ## Module: Dasharo compatibility
 

--- a/docs/variants/dell_optiplex/test-matrix.md
+++ b/docs/variants/dell_optiplex/test-matrix.md
@@ -5,6 +5,14 @@
 The test matrix is used to determine the scope of tests which the DUT is
 subjected from before the release of the new binary.
 
+
+
+!!! note
+
+    Current validation baseline for this variant tracks the shared **OptiPlex
+    7010/9010 SFF** support scope. Results for other form factors (DT/MT/USFF)
+    may require separate validation scope definitions.
+
 ## Module: Dasharo compatibility
 
 | No.  | Supported test suite                              | Test suite ID | Supported test cases                 |

--- a/docs/variants/dell_optiplex/test-matrix.md
+++ b/docs/variants/dell_optiplex/test-matrix.md
@@ -5,8 +5,6 @@
 The test matrix is used to determine the scope of tests which the DUT is
 subjected from before the release of the new binary.
 
-
-
 !!! note
     Current validation baseline for this variant tracks the shared
     **OptiPlex 7010/9010 SFF** support scope. Results for other form factors


### PR DESCRIPTION
## Summary
Independent docs clarification for #1182: add explicit validation-scope note in OptiPlex test matrix.

## Change
- `docs/variants/dell_optiplex/test-matrix.md`
- Added a note clarifying that current validation baseline tracks shared 7010/9010 SFF scope, while other form factors may need separate validation scope.

## Why
Issue #1182 discussion repeatedly highlights confusion between shared support and validated coverage across form factors. This note makes the test matrix scope explicit.

Related issue: https://github.com/Dasharo/dasharo-issues/issues/1182
