### PR TITLE
Typo fix: o -> To

### DIFF
--- a/docs/variants/hardkernel_odroid_h4/releases.md
+++ b/docs/variants/hardkernel_odroid_h4/releases.md
@@ -1,6 +1,6 @@
 # Hardkernel ODROID H4 Dasharo Release Notes
 
-This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
+This is a Dasharo Pro Package Release. To obtain access to the pre-built binaries,
 you need to [subscribe to the Dasharo Pro Package subscriber](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-pro-package-subscriber).
 You can do this by purchasing a Dasharo Pro Package product from our [shop](https://shop.3mdeb.com/product/1-year-dasharo-pro-package-for-network-appliance/).
 As a subscriber, you will receive access to all firmware updates for the

--- a/docs/variants/msi_z690/releases.md
+++ b/docs/variants/msi_z690/releases.md
@@ -1,6 +1,6 @@
 # MSI PRO Z690-A (WIFI) (DDR4) Dasharo Release Notes
 
-This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
+This is a Dasharo Pro Package Release. To obtain access to the pre-built binaries,
 you need to [subscribe to the Dasharo Pro Package subscriber](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-pro-package-subscriber).
 You can do this by purchasing a Dasharo Pro Package product from our [shop](https://shop.3mdeb.com/shop/dasharo-pro-package/1year-desktop/).
 As a subscriber, you will receive access to all firmware updates for the

--- a/docs/variants/msi_z790/releases.md
+++ b/docs/variants/msi_z790/releases.md
@@ -1,6 +1,6 @@
 # MSI PRO Z790-P (WIFI) (DDR5) Dasharo Release Notes
 
-This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
+This is a Dasharo Pro Package Release. To obtain access to the pre-built binaries,
 you need to [subscribe to the Dasharo Pro Package subscriber](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-pro-package-subscriber).
 You can do this by purchasing a Dasharo Pro Package product from our [shop](https://shop.3mdeb.com/shop/dasharo-pro-package/1year-desktop/).
 As a subscriber, you will receive access to all firmware updates for the

--- a/docs/variants/pc_engines/releases_seabios.md
+++ b/docs/variants/pc_engines/releases_seabios.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
+This is a Dasharo Pro Package Release. To obtain access to the pre-built binaries,
 you need to [subscribe to the Dasharo Pro Package subscriber](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-pro-package-subscriber).
 You can do this by purchasing a Dasharo Pro Package product from our [shop](https://shop.3mdeb.com/product/1-year-dasharo-pro-package-for-network-appliance-corebootseabios/).
 As a subscriber, you will receive access to all firmware updates for the

--- a/docs/variants/pc_engines/releases_uefi.md
+++ b/docs/variants/pc_engines/releases_uefi.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
+This is a Dasharo Pro Package Release. To obtain access to the pre-built binaries,
 you need to [subscribe to the Dasharo Pro Package subscriber](https://docs.dasharo.com/ways-you-can-help-us/#become-a-dasharo-pro-package-subscriber).
 You can do this by purchasing a Dasharo Pro Package product from our [shop](https://shop.3mdeb.com/shop/dasharo-pro-package/1year-desktop/).
 As a subscriber, you will receive access to all firmware updates for the


### PR DESCRIPTION
This is consistent to what's written for 9 other variants:
```
➜  docs git:(master) grep -r " o obtain"
docs/variants/msi_z790/releases.md:This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
docs/variants/msi_z690/releases.md:This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
docs/variants/pc_engines/releases_seabios.md:This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
docs/variants/pc_engines/releases_uefi.md:This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
docs/variants/hardkernel_odroid_h4/releases.md:This is a Dasharo Pro Package Release. o obtain access to the pre-built binaries,
➜  docs git:(master) cd docs/variants 
➜  variants git:(master) grep -r " To obtain"
msi_z790/releases.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
novacustom_v540tu/releases_heads.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
novacustom_v560tu/releases_heads.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
dell_optiplex/releases.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
msi_z690/releases_heads.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
msi_z690/releases.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
msi_z690/releases.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
pc_engines/releases_seabios.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
novacustom_nv4x_adl/releases_heads.md:This is a Dasharo Pro Package Release. To obtain access to the pre-built
```